### PR TITLE
feat: add Linux support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ echo '{"session_id":"test-123","cwd":"/tmp"}' | npx tsx src/bin/ccm.tsx hook Pre
 
 ## Architecture
 
-Claude Codeの複数セッションをリアルタイム監視するmacOS専用CLIツール。Ink（React for CLI）を使用したTUIとファイルベースの状態管理で動作する。
+Claude Codeの複数セッションをリアルタイム監視するmacOS/Linux対応CLIツール。Ink（React for CLI）を使用したTUIとファイルベースの状態管理で動作する。
 
 ### 重要なファイルパス
 
@@ -69,7 +69,7 @@ Claude Codeの複数セッションをリアルタイム監視するmacOS専用C
 - **ファイル監視**: chokidar
 - **WebSocket**: ws
 - **QRコード生成**: qrcode-terminal
-- **ターミナル制御**: AppleScript（iTerm2, Terminal.app, Ghostty対応）
+- **ターミナル制御**: AppleScript（macOS: iTerm2, Terminal.app, Ghostty対応）、xdotool（Linux）
 - **テスト**: Vitest
 - **リント/フォーマット**: Biome
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/claude-code-monitor.svg)](https://www.npmjs.com/package/claude-code-monitor)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![macOS](https://img.shields.io/badge/platform-macOS-lightgrey.svg)](https://www.apple.com/macos/)
+[![Linux](https://img.shields.io/badge/platform-Linux-lightgrey.svg)](https://www.linux.org/)
 
 **Monitor multiple Claude Code sessions in real-time from your terminal or smartphone.**
 
@@ -39,11 +40,26 @@ Control from your phone (same Wi-Fi required)
 
 ## 📋 Requirements
 
-> **Note**: This tool is **macOS only** due to its use of AppleScript for terminal control.
-
-- **macOS**
+- **macOS** or **Linux**
 - **Node.js** >= 18.0.0
 - **Claude Code** installed
+
+### Linux Requirements (for focus/keystroke features)
+
+The terminal focus and keystroke features require `xdotool` on Linux:
+
+```bash
+# Debian/Ubuntu
+sudo apt install xdotool
+
+# Fedora
+sudo dnf install xdotool
+
+# Arch
+sudo pacman -S xdotool
+```
+
+> **Note**: The core monitoring functionality works without `xdotool`. Only the terminal focus and send-text features require it.
 
 ---
 
@@ -123,7 +139,7 @@ Monitor and control Claude Code sessions from your smartphone.
 
 ### Security
 
-> **Important**: Your smartphone and Mac must be on the **same Wi-Fi network**.
+> **Important**: Your smartphone and computer must be on the **same Wi-Fi network**.
 
 - **Token Authentication** - A unique token is generated for authentication
 - **Local Network Only** - Not accessible from the internet
@@ -135,13 +151,21 @@ Monitor and control Claude Code sessions from your smartphone.
 
 ## 🖥️ Supported Terminals
 
+### macOS
+
 | Terminal | Focus Support | Notes |
 |----------|--------------|-------|
 | iTerm2 | ✅ Full | TTY-based window/tab targeting |
 | Terminal.app | ✅ Full | TTY-based window/tab targeting |
 | Ghostty | ✅ Full | Title-based window targeting via Window menu |
 
-> Other terminals can use monitoring, but focus feature is not supported.
+### Linux
+
+| Terminal | Focus Support | Notes |
+|----------|--------------|-------|
+| Any terminal | ✅ (with xdotool) | Process-based window targeting |
+
+> Monitoring works with all terminals. Focus feature requires xdotool on Linux.
 
 ### Ghostty Users
 
@@ -170,11 +194,17 @@ If you skipped this during setup and want to enable it later, add the setting ma
 2. Check `~/.claude/settings.json` for hook settings
 3. Restart Claude Code
 
-### Focus not working
+### Focus not working (macOS)
 
 1. Verify you're using a supported terminal
 2. Check System Preferences > Privacy & Security > Accessibility
    - Ensure your terminal app has Accessibility permission
+
+### Focus not working (Linux)
+
+1. Install xdotool: `sudo apt install xdotool`
+2. Ensure you're running an X11 or XWayland session
+   - Wayland-only sessions may have limited support
 
 ### Reset data
 
@@ -194,7 +224,7 @@ ccm clear
 
 - **No data sent to external servers** - All data stays on your machine
 - Hook registration modifies `~/.claude/settings.json`
-- Focus feature uses AppleScript for terminal control
+- Focus feature uses AppleScript (macOS) or xdotool (Linux) for terminal control
 - Mobile Web uses token authentication on local network only
 - Server-side validation blocks dangerous shell commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.1.11",
       "license": "MIT",
       "os": [
-        "darwin"
+        "darwin",
+        "linux"
       ],
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -1147,7 +1148,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1964,7 +1964,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2014,7 +2013,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2319,7 +2317,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2373,7 +2370,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2449,7 +2445,6 @@
       "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.17",
         "@vitest/mocker": "4.0.17",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "node": ">=18.0.0"
   },
   "os": [
-    "darwin"
+    "darwin",
+    "linux"
   ],
   "dependencies": {
     "chokidar": "^4.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,13 @@ export type {
   SessionStatus,
   StoreData,
 } from './types/index.js';
-export { focusSession, getSupportedTerminals, isMacOS } from './utils/focus.js';
-export { sendTextToTerminal } from './utils/send-text.js';
+export {
+  focusSession,
+  getSupportedTerminals,
+  isFocusAvailable,
+  isLinux,
+  isMacOS,
+} from './utils/focus.js';
+export { sendKeystrokeToTerminal, sendTextToTerminal } from './utils/send-text.js';
 // Utilities
 export { getStatusDisplay } from './utils/status.js';

--- a/src/utils/focus.ts
+++ b/src/utils/focus.ts
@@ -1,5 +1,10 @@
 import { accessSync, constants, writeFileSync } from 'node:fs';
 import { executeAppleScript } from './applescript.js';
+import {
+  focusSessionLinux,
+  getSupportedTerminalsLinux,
+  isLinuxFocusAvailable,
+} from './linux-terminal.js';
 import { executeWithTerminalFallback } from './terminal-strategy.js';
 
 /**
@@ -197,17 +202,44 @@ export function isMacOS(): boolean {
   return process.platform === 'darwin';
 }
 
+export function isLinux(): boolean {
+  return process.platform === 'linux';
+}
+
 export function focusSession(tty: string): boolean {
-  if (!isMacOS()) return false;
   if (!isValidTtyPath(tty)) return false;
 
-  return executeWithTerminalFallback({
-    iTerm2: () => focusITerm2(tty),
-    terminalApp: () => focusTerminalApp(tty),
-    ghostty: () => focusGhostty(tty),
-  });
+  if (isMacOS()) {
+    return executeWithTerminalFallback({
+      iTerm2: () => focusITerm2(tty),
+      terminalApp: () => focusTerminalApp(tty),
+      ghostty: () => focusGhostty(tty),
+    });
+  }
+
+  if (isLinux()) {
+    return focusSessionLinux(tty);
+  }
+
+  return false;
 }
 
 export function getSupportedTerminals(): string[] {
-  return ['iTerm2', 'Terminal.app', 'Ghostty'];
+  if (isMacOS()) {
+    return ['iTerm2', 'Terminal.app', 'Ghostty'];
+  }
+  if (isLinux()) {
+    return getSupportedTerminalsLinux();
+  }
+  return [];
+}
+
+export function isFocusAvailable(): boolean {
+  if (isMacOS()) {
+    return true; // AppleScript is always available on macOS
+  }
+  if (isLinux()) {
+    return isLinuxFocusAvailable();
+  }
+  return false;
 }

--- a/src/utils/linux-terminal.ts
+++ b/src/utils/linux-terminal.ts
@@ -1,0 +1,258 @@
+import { execSync, spawnSync } from 'node:child_process';
+import { isValidTtyPath } from './focus.js';
+
+/**
+ * Check if a command exists on the system.
+ * @internal
+ */
+function commandExists(cmd: string): boolean {
+  try {
+    execSync(`which ${cmd}`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if xdotool is available.
+ * @internal
+ */
+export function hasXdotool(): boolean {
+  return commandExists('xdotool');
+}
+
+/**
+ * Check if wmctrl is available.
+ * @internal
+ */
+export function hasWmctrl(): boolean {
+  return commandExists('wmctrl');
+}
+
+/**
+ * Get the PID of the process controlling a TTY.
+ * @internal
+ */
+function getTtyPid(tty: string): number | null {
+  try {
+    // Use fuser to find processes using the TTY
+    const result = spawnSync('fuser', [tty], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    // fuser outputs PIDs to stderr
+    const output = (result.stderr || result.stdout || '').trim();
+    const pids = output.split(/\s+/).filter((p) => /^\d+$/.test(p));
+    if (pids.length > 0) {
+      return parseInt(pids[0], 10);
+    }
+  } catch {
+    // fuser not available or failed
+  }
+  return null;
+}
+
+/**
+ * Get window ID(s) associated with a PID using wmctrl.
+ * @internal
+ */
+function getWindowIdByPid(pid: number): string | null {
+  if (!hasWmctrl()) return null;
+
+  try {
+    const result = execSync('wmctrl -lp', { encoding: 'utf-8' });
+    const lines = result.split('\n');
+    for (const line of lines) {
+      const parts = line.split(/\s+/);
+      if (parts.length >= 3) {
+        const winId = parts[0];
+        const winPid = parseInt(parts[2], 10);
+        if (winPid === pid) {
+          return winId;
+        }
+      }
+    }
+  } catch {
+    // wmctrl failed
+  }
+  return null;
+}
+
+/**
+ * Get window ID using xdotool search by PID.
+ * @internal
+ */
+function getWindowIdByPidXdotool(pid: number): string | null {
+  if (!hasXdotool()) return null;
+
+  try {
+    const result = execSync(`xdotool search --pid ${pid}`, {
+      encoding: 'utf-8',
+    }).trim();
+    const windowIds = result.split('\n').filter((id) => id.length > 0);
+    if (windowIds.length > 0) {
+      return windowIds[0];
+    }
+  } catch {
+    // xdotool search failed
+  }
+  return null;
+}
+
+/**
+ * Focus a window by its window ID using xdotool.
+ * @internal
+ */
+function focusWindowXdotool(windowId: string): boolean {
+  if (!hasXdotool()) return false;
+
+  try {
+    execSync(`xdotool windowactivate ${windowId}`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Focus a window by its window ID using wmctrl.
+ * @internal
+ */
+function focusWindowWmctrl(windowId: string): boolean {
+  if (!hasWmctrl()) return false;
+
+  try {
+    execSync(`wmctrl -i -a ${windowId}`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Focus the terminal session associated with a TTY on Linux.
+ * Requires xdotool or wmctrl to be installed.
+ *
+ * @param tty - The TTY path (e.g., /dev/pts/0)
+ * @returns true if focus was successful, false otherwise
+ */
+export function focusSessionLinux(tty: string): boolean {
+  if (!isValidTtyPath(tty)) return false;
+
+  // Get the PID controlling this TTY
+  const pid = getTtyPid(tty);
+  if (!pid) return false;
+
+  // Try xdotool first (more widely available)
+  let windowId = getWindowIdByPidXdotool(pid);
+  if (windowId) {
+    if (focusWindowXdotool(windowId)) return true;
+  }
+
+  // Fall back to wmctrl
+  windowId = getWindowIdByPid(pid);
+  if (windowId) {
+    if (focusWindowWmctrl(windowId)) return true;
+    if (focusWindowXdotool(windowId)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Send text to a terminal session on Linux using xdotool.
+ * Focuses the window and types the text followed by Enter.
+ *
+ * @param tty - The TTY path (e.g., /dev/pts/0)
+ * @param text - The text to send
+ * @returns true if successful, false otherwise
+ */
+export function sendTextToTerminalLinux(tty: string, text: string): boolean {
+  if (!hasXdotool()) return false;
+  if (!isValidTtyPath(tty)) return false;
+
+  // Focus the window first
+  if (!focusSessionLinux(tty)) return false;
+
+  try {
+    // Small delay to ensure window is focused
+    execSync('sleep 0.1', { stdio: 'pipe' });
+
+    // Type the text and press Enter
+    // Use --clearmodifiers to handle any held keys
+    execSync(`xdotool type --clearmodifiers -- "${text.replace(/"/g, '\\"')}"`, {
+      stdio: 'pipe',
+    });
+    execSync('xdotool key Return', { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Send a single keystroke to a terminal session on Linux using xdotool.
+ *
+ * @param tty - The TTY path (e.g., /dev/pts/0)
+ * @param key - The key to send (e.g., 'y', 'n', 'Return', 'Escape')
+ * @param useControl - Whether to hold Ctrl while pressing the key
+ * @returns true if successful, false otherwise
+ */
+export function sendKeystrokeToTerminalLinux(
+  tty: string,
+  key: string,
+  useControl = false
+): boolean {
+  if (!hasXdotool()) return false;
+  if (!isValidTtyPath(tty)) return false;
+
+  // Focus the window first
+  if (!focusSessionLinux(tty)) return false;
+
+  try {
+    // Small delay to ensure window is focused
+    execSync('sleep 0.1', { stdio: 'pipe' });
+
+    // Map common key names
+    let xdotoolKey = key;
+    const lowerKey = key.toLowerCase();
+    if (lowerKey === 'escape') {
+      xdotoolKey = 'Escape';
+    } else if (key.length === 1) {
+      xdotoolKey = key;
+    }
+
+    // Build the command
+    const cmd = useControl
+      ? `xdotool key --clearmodifiers ctrl+${xdotoolKey}`
+      : `xdotool key --clearmodifiers ${xdotoolKey}`;
+
+    execSync(cmd, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get list of supported terminal emulators on Linux.
+ */
+export function getSupportedTerminalsLinux(): string[] {
+  const terminals: string[] = [];
+  if (hasXdotool()) {
+    terminals.push('Any terminal (via xdotool)');
+  }
+  if (hasWmctrl()) {
+    terminals.push('Any terminal (via wmctrl)');
+  }
+  return terminals;
+}
+
+/**
+ * Check if Linux terminal focus is available.
+ * Returns true if at least one of xdotool or wmctrl is installed.
+ */
+export function isLinuxFocusAvailable(): boolean {
+  return hasXdotool() || hasWmctrl();
+}

--- a/src/utils/send-text.ts
+++ b/src/utils/send-text.ts
@@ -1,11 +1,17 @@
 import { executeAppleScript } from './applescript.js';
 import {
   generateTitleTag,
+  isLinux,
   isMacOS,
   isValidTtyPath,
   sanitizeForAppleScript,
   setTtyTitle,
 } from './focus.js';
+import {
+  hasXdotool,
+  sendKeystrokeToTerminalLinux,
+  sendTextToTerminalLinux,
+} from './linux-terminal.js';
 import { executeWithTerminalFallback } from './terminal-strategy.js';
 
 /**
@@ -345,14 +351,16 @@ function sendKeystrokeToGhostty(
 
 /**
  * Send text to a terminal session and execute it (press Enter).
- * Tries iTerm2, Terminal.app, and Ghostty in order.
+ * On macOS: Tries iTerm2, Terminal.app, and Ghostty in order.
+ * On Linux: Uses xdotool if available.
  *
  * @param tty - The TTY path of the target terminal session
  * @param text - The text to send to the terminal
- * @returns true if text was sent successfully, false otherwise
+ * @returns Result object with success status and optional error message
  *
  * @remarks
- * - This is macOS only (uses AppleScript)
+ * - macOS: Uses AppleScript for iTerm2, Terminal.app, and Ghostty
+ * - Linux: Uses xdotool (must be installed)
  * - For iTerm2 and Terminal.app, targets specific TTY
  * - For Ghostty, sends to the active window (TTY targeting not supported)
  * - System Events usage for Ghostty may require accessibility permissions
@@ -361,10 +369,6 @@ export function sendTextToTerminal(
   tty: string,
   text: string
 ): { success: boolean; error?: string } {
-  if (!isMacOS()) {
-    return { success: false, error: 'This feature is only available on macOS' };
-  }
-
   if (!isValidTtyPath(tty)) {
     return { success: false, error: 'Invalid TTY path' };
   }
@@ -374,15 +378,32 @@ export function sendTextToTerminal(
     return { success: false, error: validation.error };
   }
 
-  const success = executeWithTerminalFallback({
-    iTerm2: () => sendTextToITerm2(tty, text),
-    terminalApp: () => sendTextToTerminalApp(tty, text),
-    ghostty: () => sendTextToGhostty(tty, text),
-  });
+  if (isMacOS()) {
+    const success = executeWithTerminalFallback({
+      iTerm2: () => sendTextToITerm2(tty, text),
+      terminalApp: () => sendTextToTerminalApp(tty, text),
+      ghostty: () => sendTextToGhostty(tty, text),
+    });
 
-  return success
-    ? { success: true }
-    : { success: false, error: 'Could not send text to any terminal' };
+    return success
+      ? { success: true }
+      : { success: false, error: 'Could not send text to any terminal' };
+  }
+
+  if (isLinux()) {
+    if (!hasXdotool()) {
+      return {
+        success: false,
+        error: 'xdotool is required on Linux. Install with: sudo apt install xdotool',
+      };
+    }
+    const success = sendTextToTerminalLinux(tty, text);
+    return success
+      ? { success: true }
+      : { success: false, error: 'Could not send text to terminal' };
+  }
+
+  return { success: false, error: 'This feature is only available on macOS and Linux' };
 }
 
 /**
@@ -423,10 +444,6 @@ export function sendKeystrokeToTerminal(
   key: string,
   useControl = false
 ): { success: boolean; error?: string } {
-  if (!isMacOS()) {
-    return { success: false, error: 'This feature is only available on macOS' };
-  }
-
   if (!isValidTtyPath(tty)) {
     return { success: false, error: 'Invalid TTY path' };
   }
@@ -449,16 +466,33 @@ export function sendKeystrokeToTerminal(
     return { success: false, error: 'Only Ctrl+C is supported' };
   }
 
-  // Determine if we need to use key code (for Escape key)
-  const useKeyCode = isEscapeKey ? ESCAPE_KEY_CODE : undefined;
+  if (isMacOS()) {
+    // Determine if we need to use key code (for Escape key)
+    const useKeyCode = isEscapeKey ? ESCAPE_KEY_CODE : undefined;
 
-  const success = executeWithTerminalFallback({
-    iTerm2: () => sendKeystrokeToITerm2(tty, key, useControl, useKeyCode),
-    terminalApp: () => sendKeystrokeToTerminalApp(tty, key, useControl, useKeyCode),
-    ghostty: () => sendKeystrokeToGhostty(tty, key, useControl, useKeyCode),
-  });
+    const success = executeWithTerminalFallback({
+      iTerm2: () => sendKeystrokeToITerm2(tty, key, useControl, useKeyCode),
+      terminalApp: () => sendKeystrokeToTerminalApp(tty, key, useControl, useKeyCode),
+      ghostty: () => sendKeystrokeToGhostty(tty, key, useControl, useKeyCode),
+    });
 
-  return success
-    ? { success: true }
-    : { success: false, error: 'Could not send keystroke to any terminal' };
+    return success
+      ? { success: true }
+      : { success: false, error: 'Could not send keystroke to any terminal' };
+  }
+
+  if (isLinux()) {
+    if (!hasXdotool()) {
+      return {
+        success: false,
+        error: 'xdotool is required on Linux. Install with: sudo apt install xdotool',
+      };
+    }
+    const success = sendKeystrokeToTerminalLinux(tty, key, useControl);
+    return success
+      ? { success: true }
+      : { success: false, error: 'Could not send keystroke to terminal' };
+  }
+
+  return { success: false, error: 'This feature is only available on macOS and Linux' };
 }

--- a/tests/focus.test.ts
+++ b/tests/focus.test.ts
@@ -146,14 +146,26 @@ describe('focus', () => {
     it('should return array of supported terminal names', () => {
       const terminals = getSupportedTerminals();
       expect(Array.isArray(terminals)).toBe(true);
-      expect(terminals).toContain('iTerm2');
-      expect(terminals).toContain('Terminal.app');
-      expect(terminals).toContain('Ghostty');
+      // On macOS, should return specific terminal names
+      if (process.platform === 'darwin') {
+        expect(terminals).toContain('iTerm2');
+        expect(terminals).toContain('Terminal.app');
+        expect(terminals).toContain('Ghostty');
+      }
+      // On Linux, returns terminals based on available tools (xdotool/wmctrl)
+      // or empty array if none are available
     });
 
-    it('should return exactly 3 terminals', () => {
+    it('should return appropriate number of terminals for platform', () => {
       const terminals = getSupportedTerminals();
-      expect(terminals).toHaveLength(3);
+      if (process.platform === 'darwin') {
+        expect(terminals).toHaveLength(3);
+      } else if (process.platform === 'linux') {
+        // On Linux, depends on whether xdotool/wmctrl are installed
+        expect(terminals.length).toBeGreaterThanOrEqual(0);
+      } else {
+        expect(terminals).toHaveLength(0);
+      }
     });
   });
 
@@ -167,16 +179,14 @@ describe('focus', () => {
     });
 
     it('should return false for invalid tty path', () => {
-      // Only test on macOS where this check is reached
-      if (process.platform === 'darwin') {
-        expect(focusSession('/invalid/path')).toBe(false);
-        expect(focusSession('')).toBe(false);
-      }
+      // This validation now happens on all platforms
+      expect(focusSession('/invalid/path')).toBe(false);
+      expect(focusSession('')).toBe(false);
     });
 
-    it('should return false on non-macOS platform', () => {
+    it('should return false on unsupported platform', () => {
       Object.defineProperty(process, 'platform', {
-        value: 'linux',
+        value: 'win32',
       });
       expect(focusSession('/dev/pts/0')).toBe(false);
     });

--- a/tests/send-text.test.ts
+++ b/tests/send-text.test.ts
@@ -70,39 +70,48 @@ describe('send-text', () => {
       });
     });
 
-    it('should return error for non-macOS platform', () => {
+    it('should return error for unsupported platform', () => {
       Object.defineProperty(process, 'platform', {
-        value: 'linux',
+        value: 'win32',
       });
       const result = sendTextToTerminal('/dev/pts/0', 'test');
       expect(result.success).toBe(false);
-      expect(result.error).toBe('This feature is only available on macOS');
+      expect(result.error).toBe('This feature is only available on macOS and Linux');
+    });
+
+    it('should return error when xdotool is not available on Linux', () => {
+      // This test simulates Linux behavior where xdotool may not be installed
+      // When running on actual Linux without xdotool, it will return an error
+      if (process.platform === 'linux') {
+        const result = sendTextToTerminal('/dev/pts/0', 'test');
+        expect(result.success).toBe(false);
+        // Either xdotool is not installed or focus failed
+        expect(result.error).toBeDefined();
+      }
     });
 
     it('should return error for invalid tty path', () => {
-      // Only test on macOS where this check is reached
-      if (process.platform === 'darwin') {
-        const result = sendTextToTerminal('/invalid/path', 'test');
-        expect(result.success).toBe(false);
-        expect(result.error).toBe('Invalid TTY path');
-      }
+      // This validation now happens on both macOS and Linux
+      const result = sendTextToTerminal('/invalid/path', 'test');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid TTY path');
     });
 
     it('should return error for empty text', () => {
-      if (process.platform === 'darwin') {
-        const result = sendTextToTerminal('/dev/ttys001', '');
-        expect(result.success).toBe(false);
-        expect(result.error).toBe('Text cannot be empty');
-      }
+      // Text validation happens before platform-specific code
+      const ttyPath = process.platform === 'darwin' ? '/dev/ttys001' : '/dev/pts/0';
+      const result = sendTextToTerminal(ttyPath, '');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Text cannot be empty');
     });
 
     it('should return error for text exceeding max length', () => {
-      if (process.platform === 'darwin') {
-        const longText = 'a'.repeat(10001);
-        const result = sendTextToTerminal('/dev/ttys001', longText);
-        expect(result.success).toBe(false);
-        expect(result.error).toContain('exceeds maximum length');
-      }
+      // Text validation happens before platform-specific code
+      const ttyPath = process.platform === 'darwin' ? '/dev/ttys001' : '/dev/pts/0';
+      const longText = 'a'.repeat(10001);
+      const result = sendTextToTerminal(ttyPath, longText);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('exceeds maximum length');
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR adds Linux support to claude-code-monitor, allowing the tool to run on Linux systems in addition to macOS.

- Add "linux" to the supported platforms in package.json
- Implement Linux terminal focus using `xdotool` and `wmctrl`
- Add Linux support for `sendTextToTerminal` and `sendKeystrokeToTerminal` 
- Update tests to be platform-aware
- Update documentation with Linux requirements and instructions

## Changes

### Core Changes
- **package.json**: Add `"linux"` to the `"os"` array
- **src/utils/linux-terminal.ts**: New file implementing Linux terminal operations using `xdotool`/`wmctrl`
- **src/utils/focus.ts**: Update to use Linux implementation when on Linux
- **src/utils/send-text.ts**: Update to use Linux implementation when on Linux
- **src/index.ts**: Export new helper functions (`isLinux`, `isFocusAvailable`)

### Documentation
- **README.md**: Add Linux badge, update requirements, add Linux-specific instructions
- **CLAUDE.md**: Update architecture description to mention Linux support

### Tests
- **tests/focus.test.ts**: Update tests to be platform-aware
- **tests/send-text.test.ts**: Update tests to be platform-aware

## Linux Implementation Details

On Linux, terminal focus uses:
1. `fuser` to find the process controlling a TTY
2. `xdotool` to search for windows by PID and focus them
3. `wmctrl` as a fallback for window management

The core monitoring functionality works without any additional dependencies. Only the terminal focus and send-text features require `xdotool`.

## Test plan

- [x] `npm run build` - TypeScript compilation succeeds
- [x] `npm run typecheck` - Type checking passes
- [x] `npm run lint` - Linting passes
- [x] `npm test` - All 71 tests pass
- [x] `npm start -- --help` - CLI runs correctly on Linux

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/code)