### PR TITLE
feat: display terminal tab name in session cards

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1389,8 +1389,8 @@
       const isWaiting = session.status === 'waiting_input';
 
       targetSession = id;
-      $modalTitle.textContent = getDirName(session.cwd);
-      $modalPath.textContent = formatPath(session.cwd);
+      $modalTitle.textContent = session.tabName || getDirName(session.cwd);
+      $modalPath.textContent = session.tabName ? getDirName(session.cwd) + ' · ' + formatPath(session.cwd) : formatPath(session.cwd);
       $modalMessageLabel.textContent = 'Message';
       $modalMessage.innerHTML = renderMarkdown(session.lastMessage);
       $msgInput.value = '';
@@ -1432,8 +1432,8 @@
 
       const isWaiting = session.status === 'waiting_input';
 
-      $modalTitle.textContent = getDirName(session.cwd);
-      $modalPath.textContent = formatPath(session.cwd);
+      $modalTitle.textContent = session.tabName || getDirName(session.cwd);
+      $modalPath.textContent = session.tabName ? getDirName(session.cwd) + ' · ' + formatPath(session.cwd) : formatPath(session.cwd);
       $modalMessage.innerHTML = renderMarkdown(session.lastMessage);
 
       // Update waiting state (keep input enabled for text input)
@@ -1802,6 +1802,9 @@
         const statusLabel = escapeHtml(STATUS[session.status]);
         const msgPreview = escapeHtml(truncateMessage(session.lastMessage));
         const safeStatus = escapeHtml(session.status);
+        const safeTabName = session.tabName ? escapeHtml(session.tabName) : '';
+        const cardTitle = safeTabName || dirName;
+        const cardSubtitle = safeTabName ? dirName + ' · ' + shortPath : shortPath;
 
         return `
           <div class="card ${safeStatus}" data-session-id="${escapeHtml(session.session_id)}">
@@ -1811,8 +1814,8 @@
               <span class="card-status-chevron">›</span>
             </div>
             <div class="card-body">
-              <div class="card-name">${dirName}</div>
-              <div class="card-path">${shortPath}</div>
+              <div class="card-name">${cardTitle}</div>
+              <div class="card-path">${cardSubtitle}</div>
               <div class="card-message">
                 ${msgPreview
                   ? `<div class="card-message-text">${msgPreview}</div>`

--- a/src/bin/ccm.tsx
+++ b/src/bin/ccm.tsx
@@ -129,7 +129,11 @@ program
     for (const session of sessions) {
       const cwd = session.cwd.replace(/^\/Users\/[^/]+/, '~');
       const { symbol } = getStatusDisplay(session.status);
-      console.log(`${symbol} ${cwd}`);
+      if (session.tabName) {
+        console.log(`${symbol} ${session.tabName} (${cwd})`);
+      } else {
+        console.log(`${symbol} ${cwd}`);
+      }
     }
   });
 

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -38,7 +38,14 @@ export const SessionCard = memo(function SessionCard({
       </Box>
       <Text> </Text>
       <Text dimColor>{relativeTime.padEnd(8)}</Text>
-      <Text color={isSelected ? 'white' : 'gray'}>{dir}</Text>
+      {session.tabName ? (
+        <>
+          <Text color="cyan">{session.tabName}</Text>
+          <Text dimColor> {dir}</Text>
+        </>
+      ) : (
+        <Text color={isSelected ? 'white' : 'gray'}>{dir}</Text>
+      )}
     </Box>
   );
 });

--- a/src/store/file-store.ts
+++ b/src/store/file-store.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { WRITE_DEBOUNCE_MS } from '../constants.js';
 import type { HookEvent, Session, SessionStatus, StoreData } from '../types/index.js';
+import { enrichSessionsWithTabNames } from '../utils/tab-name.js';
 import { getLastAssistantMessage } from '../utils/transcript.js';
 import { isTtyAlive } from '../utils/tty-cache.js';
 
@@ -204,8 +205,10 @@ export function getSessions(): Session[] {
     writeStore(store);
   }
 
-  return Object.values(store.sessions).sort(
-    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  return enrichSessionsWithTabNames(
+    Object.values(store.sessions).sort(
+      (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    )
   );
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,7 @@ export interface Session {
   created_at: string;
   updated_at: string;
   lastMessage?: string;
+  tabName?: string;
 }
 
 // File store data structure

--- a/src/utils/applescript.ts
+++ b/src/utils/applescript.ts
@@ -16,3 +16,21 @@ export function executeAppleScript(script: string): boolean {
     return false;
   }
 }
+
+/**
+ * Execute an AppleScript and return the result as a string.
+ * @param script - AppleScript code to execute
+ * @returns trimmed result string, or null on failure/empty result
+ */
+export function executeAppleScriptWithResult(script: string): string | null {
+  try {
+    const result = execFileSync('osascript', ['-e', script], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    }).trim();
+    return result || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/screen-capture.ts
+++ b/src/utils/screen-capture.ts
@@ -1,7 +1,8 @@
-import { execFile, execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { readFile, unlink } from 'node:fs/promises';
 import { promisify } from 'node:util';
+import { executeAppleScriptWithResult } from './applescript.js';
 import { generateTitleTag, sanitizeForAppleScript, setTtyTitle } from './focus.js';
 
 const execFileAsync = promisify(execFile);
@@ -79,23 +80,6 @@ const TTY_PATH_PATTERN = /^\/dev\/(ttys?\d+|pts\/\d+)$/;
  */
 function isValidTtyPath(tty: string): boolean {
   return TTY_PATH_PATTERN.test(tty);
-}
-
-/**
- * Execute an AppleScript and return the result as a string.
- * @internal
- */
-function executeAppleScriptWithResult(script: string): string | null {
-  try {
-    const result = execFileSync('osascript', ['-e', script], {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 10000,
-    }).trim();
-    return result;
-  } catch {
-    return null;
-  }
 }
 
 /**

--- a/src/utils/tab-name.ts
+++ b/src/utils/tab-name.ts
@@ -1,0 +1,102 @@
+import { TTY_CACHE_TTL_MS } from '../constants.js';
+import type { Session } from '../types/index.js';
+import { executeAppleScriptWithResult } from './applescript.js';
+import { sanitizeForAppleScript } from './focus.js';
+
+interface CacheEntry {
+  name: string | null;
+  fetchedAt: number;
+}
+
+const tabNameCache = new Map<string, CacheEntry>();
+
+/** @internal - exported for testing */
+export function clearTabNameCache(): void {
+  tabNameCache.clear();
+}
+
+/** @internal */
+export function buildITerm2TabNameScript(tty: string): string {
+  const safeTty = sanitizeForAppleScript(tty);
+  return `
+tell application "System Events"
+  if not (exists process "iTerm2") then return ""
+end tell
+
+tell application "iTerm2"
+  repeat with aWindow in windows
+    repeat with aTab in tabs of aWindow
+      repeat with aSession in sessions of aTab
+        if tty of aSession is "${safeTty}" then
+          return name of aSession
+        end if
+      end repeat
+    end repeat
+  end repeat
+end tell
+return ""
+`;
+}
+
+/** @internal */
+export function buildTerminalAppTabNameScript(tty: string): string {
+  const safeTty = sanitizeForAppleScript(tty);
+  return `
+tell application "System Events"
+  if not (exists process "Terminal") then return ""
+end tell
+
+tell application "Terminal"
+  repeat with aWindow in windows
+    repeat with aTab in tabs of aWindow
+      if tty of aTab is "${safeTty}" then
+        set tabTitle to custom title of aTab
+        if tabTitle is not "" then return tabTitle
+        return name of aTab
+      end if
+    end repeat
+  end repeat
+end tell
+return ""
+`;
+}
+
+/** Ghostty lacks per-tab AppleScript API */
+export function buildGhosttyTabNameScript(): null {
+  return null;
+}
+
+export function getTabName(tty: string): string | null {
+  const now = Date.now();
+  const cached = tabNameCache.get(tty);
+  if (cached && now - cached.fetchedAt < TTY_CACHE_TTL_MS) {
+    return cached.name;
+  }
+
+  let name: string | null = null;
+
+  // Try iTerm2
+  const iterm2Result = executeAppleScriptWithResult(buildITerm2TabNameScript(tty));
+  if (iterm2Result) {
+    name = iterm2Result;
+  } else {
+    // Try Terminal.app
+    const terminalResult = executeAppleScriptWithResult(buildTerminalAppTabNameScript(tty));
+    if (terminalResult) {
+      name = terminalResult;
+    }
+    // Ghostty: no per-tab API, skip
+  }
+
+  tabNameCache.set(tty, { name, fetchedAt: now });
+  return name;
+}
+
+export function enrichSessionsWithTabNames(sessions: Session[]): Session[] {
+  return sessions.map((session) => {
+    if (!session.tty) return session;
+    const tabName = getTabName(session.tty);
+    if (!tabName) return session;
+    return { ...session, tabName };
+  });
+}

--- a/tests/file-store.test.ts
+++ b/tests/file-store.test.ts
@@ -14,6 +14,11 @@ vi.mock('node:os', async (importOriginal) => {
   };
 });
 
+// Mock tab-name enrichment to avoid real AppleScript execution in tests
+vi.mock('../src/utils/tab-name.js', () => ({
+  enrichSessionsWithTabNames: (sessions: unknown[]) => sessions,
+}));
+
 // Mock isTtyAlive to return true for most TTYs, but false for specific test paths
 vi.mock('../src/utils/tty-cache.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('../src/utils/tty-cache.js')>();

--- a/tests/tab-name.test.ts
+++ b/tests/tab-name.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/utils/applescript.js', () => ({
+  executeAppleScriptWithResult: vi.fn(),
+}));
+
+import type { Session } from '../src/types/index.js';
+import { executeAppleScriptWithResult } from '../src/utils/applescript.js';
+import {
+  buildGhosttyTabNameScript,
+  buildITerm2TabNameScript,
+  buildTerminalAppTabNameScript,
+  clearTabNameCache,
+  enrichSessionsWithTabNames,
+  getTabName,
+} from '../src/utils/tab-name.js';
+
+const mockExecute = vi.mocked(executeAppleScriptWithResult);
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    session_id: 'test-123',
+    cwd: '/Users/test/project',
+    tty: '/dev/ttys001',
+    status: 'running',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('tab-name', () => {
+  beforeEach(() => {
+    clearTabNameCache();
+    mockExecute.mockReset();
+  });
+
+  afterEach(() => {
+    clearTabNameCache();
+  });
+
+  describe('AppleScript builders', () => {
+    it('buildITerm2TabNameScript produces script with TTY', () => {
+      const script = buildITerm2TabNameScript('/dev/ttys001');
+      expect(script).toContain('iTerm2');
+      expect(script).toContain('/dev/ttys001');
+      expect(script).toContain('name of aSession');
+    });
+
+    it('buildTerminalAppTabNameScript produces script with TTY', () => {
+      const script = buildTerminalAppTabNameScript('/dev/ttys001');
+      expect(script).toContain('Terminal');
+      expect(script).toContain('/dev/ttys001');
+      expect(script).toContain('custom title of aTab');
+    });
+
+    it('buildGhosttyTabNameScript returns null', () => {
+      expect(buildGhosttyTabNameScript()).toBeNull();
+    });
+
+    it('buildITerm2TabNameScript escapes special characters in TTY', () => {
+      const script = buildITerm2TabNameScript('/dev/ttys"001');
+      expect(script).toContain('\\"');
+    });
+  });
+
+  describe('getTabName', () => {
+    it('returns name from iTerm2 when available', () => {
+      mockExecute.mockReturnValueOnce('My Tab');
+      const result = getTabName('/dev/ttys001');
+      expect(result).toBe('My Tab');
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to Terminal.app when iTerm2 returns null', () => {
+      mockExecute.mockReturnValueOnce(null);
+      mockExecute.mockReturnValueOnce('Terminal Tab');
+      const result = getTabName('/dev/ttys001');
+      expect(result).toBe('Terminal Tab');
+      expect(mockExecute).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns null when no terminal returns a name', () => {
+      mockExecute.mockReturnValue(null);
+      const result = getTabName('/dev/ttys001');
+      expect(result).toBeNull();
+    });
+
+    it('returns cached value without re-executing AppleScript', () => {
+      mockExecute.mockReturnValueOnce('Cached Tab');
+      getTabName('/dev/ttys001');
+      mockExecute.mockClear();
+
+      const result = getTabName('/dev/ttys001');
+      expect(result).toBe('Cached Tab');
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('re-fetches after cache TTL expires', () => {
+      mockExecute.mockReturnValueOnce('Old Tab');
+      getTabName('/dev/ttys001');
+
+      // Advance time past TTL
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(31_000);
+
+      mockExecute.mockReturnValueOnce('New Tab');
+      const result = getTabName('/dev/ttys001');
+      expect(result).toBe('New Tab');
+
+      vi.useRealTimers();
+    });
+
+    it('caches null results too', () => {
+      mockExecute.mockReturnValue(null);
+      getTabName('/dev/ttys001');
+      mockExecute.mockClear();
+
+      const result = getTabName('/dev/ttys001');
+      expect(result).toBeNull();
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('enrichSessionsWithTabNames', () => {
+    it('attaches tabName when available', () => {
+      mockExecute.mockReturnValueOnce('My Tab');
+      const sessions = [makeSession()];
+      const result = enrichSessionsWithTabNames(sessions);
+      expect(result[0].tabName).toBe('My Tab');
+    });
+
+    it('passes through sessions without TTY unchanged', () => {
+      const sessions = [makeSession({ tty: undefined })];
+      const result = enrichSessionsWithTabNames(sessions);
+      expect(result[0].tabName).toBeUndefined();
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('leaves tabName undefined when AppleScript returns null', () => {
+      mockExecute.mockReturnValue(null);
+      const sessions = [makeSession()];
+      const result = enrichSessionsWithTabNames(sessions);
+      expect(result[0].tabName).toBeUndefined();
+    });
+
+    it('does not mutate original session objects', () => {
+      mockExecute.mockReturnValueOnce('Tab Name');
+      const original = makeSession();
+      const sessions = [original];
+      const result = enrichSessionsWithTabNames(sessions);
+      expect(original.tabName).toBeUndefined();
+      expect(result[0].tabName).toBe('Tab Name');
+    });
+
+    it('handles empty session list', () => {
+      const result = enrichSessionsWithTabNames([]);
+      expect(result).toEqual([]);
+    });
+
+    it('handles mixed sessions with and without TTY', () => {
+      mockExecute.mockReturnValueOnce('Named Tab');
+      const sessions = [
+        makeSession({ session_id: 's1', tty: '/dev/ttys001' }),
+        makeSession({ session_id: 's2', tty: undefined }),
+      ];
+      const result = enrichSessionsWithTabNames(sessions);
+      expect(result[0].tabName).toBe('Named Tab');
+      expect(result[1].tabName).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Resolve terminal tab names from iTerm2 and Terminal.app via AppleScript, displayed in the TUI, mobile web UI, and `ccm list` output
- Sessions sharing the same cwd are now instantly distinguishable by their tab name
- Tab names are cached for 30s (matching existing TTY cache TTL) and resolved at read-time only in display contexts

## Changes

- Extract `executeAppleScriptWithResult` from `screen-capture.ts` to shared `applescript.ts`
- Add `tabName?: string` to `Session` type (not persisted — resolved at read-time)
- New `src/utils/tab-name.ts` with AppleScript builders for iTerm2/Terminal.app, 30s TTL cache, and `enrichSessionsWithTabNames()`
- Enrich sessions in `getSessions()` (display-only path)
- Update `SessionCard` (TUI), `public/index.html` (mobile web), and `ccm list` to show tab name when available
- 16 new unit tests in `tests/tab-name.test.ts`

## Demo
![Screenshot 2026-02-19 at 2 27 20 PM](https://github.com/user-attachments/assets/28e09c50-28e8-44c9-9390-c86d70d8f79f)


## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — all tests pass (16 new + existing)
- [x] Manual: `npx tsx src/bin/ccm.tsx list` shows tab names from iTerm2
- [x] Manual: sessions without custom tab names display cwd only (no regression)