### PR TITLE
Add WezTerm terminal support and improve mobile web reliability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,7 +1147,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1964,7 +1963,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2014,7 +2012,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2319,7 +2316,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2373,7 +2369,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2449,7 +2444,6 @@
       "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.17",
         "@vitest/mocker": "4.0.17",

--- a/public/index.html
+++ b/public/index.html
@@ -1280,6 +1280,9 @@
     const SWIPE_THRESHOLD_PX = 100;
     const HEARTBEAT_INTERVAL_MS = 25000;
     const HEARTBEAT_TIMEOUT_MS = 10000;
+    const CONNECT_TIMEOUT_MS = 5000;
+    const POLL_INTERVAL_MS = 3000;
+    const WS_FAIL_POLL_THRESHOLD = 2;
 
     let ws = null;
     let targetSession = null;
@@ -1292,6 +1295,10 @@
     let heartbeatTimeoutTimer = null;
     let isConnecting = false;
     let lastConnectTime = 0;
+    let connectTimeoutTimer = null;
+    let wsConsecutiveFailures = 0;
+    let pollTimer = null;
+    let currentSocketOpened = false;
 
     // Event delegation for card clicks (safer than inline onclick)
     $sessions.addEventListener('click', (e) => {
@@ -1854,6 +1861,39 @@
       }).join('');
     }
 
+    function getAuthToken() {
+      return new URLSearchParams(window.location.search).get('token');
+    }
+
+    function fetchSessions() {
+      const token = getAuthToken();
+      if (!token) return;
+      fetch('/api/sessions?token=' + encodeURIComponent(token))
+        .then(r => r.json())
+        .then(msg => {
+          if (msg.data) {
+            render(msg.data);
+            setConn(true);
+            dbg('http poll ok');
+          }
+        })
+        .catch(() => { dbg('http poll fail'); });
+    }
+
+    function startPolling() {
+      if (pollTimer) return;
+      dbg('polling start');
+      fetchSessions();
+      pollTimer = setInterval(fetchSessions, POLL_INTERVAL_MS);
+    }
+
+    function stopPolling() {
+      if (!pollTimer) return;
+      dbg('polling stop');
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+
     function getReconnectDelay() {
       const delay = Math.min(RECONNECT_BASE_MS * Math.pow(2, reconnectAttempt), RECONNECT_MAX_MS);
       const jitter = delay * 0.3 * Math.random();
@@ -1890,6 +1930,8 @@
       stopHeartbeat();
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
+      clearTimeout(connectTimeoutTimer);
+      connectTimeoutTimer = null;
       if (ws) {
         // Remove handlers to prevent double-reconnect
         ws.onclose = null;
@@ -1924,8 +1966,7 @@
       // Prevent double-connections
       if (isConnecting) return;
 
-      const params = new URLSearchParams(window.location.search);
-      const token = params.get('token');
+      const token = getAuthToken();
 
       if (!token) {
         $sessions.innerHTML = `
@@ -1939,6 +1980,7 @@
       }
 
       isConnecting = true;
+      currentSocketOpened = false;
       lastConnectTime = Date.now();
       const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
       const wsUrl = `${proto}//${location.host}?token=${token}`;
@@ -1952,10 +1994,29 @@
       }
       dbg('ws connecting');
 
+      // iOS Safari can hang WebSocket connections indefinitely after
+      // returning from background — onopen/onclose/onerror never fire.
+      // This timeout detects the hung state and forces a retry.
+      connectTimeoutTimer = setTimeout(() => {
+        dbg('ws connect timeout');
+        teardownSocket();
+        setConn(false);
+        wsConsecutiveFailures++;
+        if (wsConsecutiveFailures >= WS_FAIL_POLL_THRESHOLD) {
+          startPolling();
+        }
+        scheduleReconnect();
+      }, CONNECT_TIMEOUT_MS);
+
       ws.onopen = () => {
+        clearTimeout(connectTimeoutTimer);
+        connectTimeoutTimer = null;
+        currentSocketOpened = true;
         dbg('ws open');
         isConnecting = false;
         reconnectAttempt = 0;
+        wsConsecutiveFailures = 0;
+        stopPolling();
         setConn(true);
         pendingSend = null;
         startHeartbeat();
@@ -1966,6 +2027,13 @@
         setConn(false);
         pendingSend = null;
         stopHeartbeat();
+        // Count as failure if the socket never opened (e.g., iOS 1006 after resume)
+        if (!currentSocketOpened) {
+          wsConsecutiveFailures++;
+          if (wsConsecutiveFailures >= WS_FAIL_POLL_THRESHOLD) {
+            startPolling();
+          }
+        }
         scheduleReconnect();
       };
       ws.onerror = (e) => {
@@ -2022,19 +2090,7 @@
 
     // Fetch sessions immediately over HTTP — renders the page without
     // waiting for the WebSocket (iOS Safari delays WS connections ~10-15s).
-    const params = new URLSearchParams(window.location.search);
-    const initToken = params.get('token');
-    if (initToken) {
-      fetch('/api/sessions?token=' + encodeURIComponent(initToken))
-        .then(r => r.json())
-        .then(msg => {
-          if (msg.data) {
-            render(msg.data);
-            setConn(true);
-          }
-        })
-        .catch(() => {});
-    }
+    fetchSessions();
 
     connect();
 
@@ -2044,6 +2100,13 @@
     document.addEventListener('visibilitychange', () => {
       dbg('visibility: ' + document.visibilityState);
       if (document.visibilityState === 'visible') {
+        // Blur input so iOS doesn't auto-open the keyboard on resume
+        if (document.activeElement && document.activeElement.tagName === 'TEXTAREA') {
+          document.activeElement.blur();
+        }
+        // Fetch fresh data immediately over HTTP — this works even when
+        // iOS Safari's WebSocket stack is still recovering from suspension.
+        fetchSessions();
         forceReconnect();
       }
     });

--- a/public/index.html
+++ b/public/index.html
@@ -1151,6 +1151,12 @@
         <span class="loading-text">Connecting...</span>
       </div>
     </div>
+    <div id="dbgWrap" style="position:fixed;bottom:0;left:0;right:0;z-index:9999;display:none;">
+      <div id="dbgTab" onclick="document.getElementById('dbg').classList.toggle('dbg-hidden');this.textContent=document.getElementById('dbg').classList.contains('dbg-hidden')?'▲ Debug':'▼ Debug'" style="background:#222;color:#0f0;font:10px monospace;padding:2px 8px;cursor:pointer;display:inline-block;border-radius:4px 4px 0 0;opacity:0.8;">▼ Debug</div>
+      <div id="dbg" style="background:#111;color:#0f0;font:10px monospace;padding:4px;max-height:15vh;overflow-y:scroll;-webkit-overflow-scrolling:touch;opacity:0.8;"></div>
+    </div>
+    <style>#dbg.dbg-hidden{display:none;}</style>
+    <script>if(new URLSearchParams(location.search).has('debug'))document.getElementById('dbgWrap').style.display='';</script>
   </div>
 
   <div class="toast" id="toast"></div>
@@ -1257,16 +1263,35 @@
     const $fullscreenClose = document.getElementById('fullscreenClose');
     const $fullscreenHint = document.getElementById('fullscreenHint');
 
+    const $dbg = document.getElementById('dbg');
+    const debugEnabled = new URLSearchParams(location.search).has('debug');
+    function dbg(msg) {
+      if (!debugEnabled) return;
+      const t = new Date().toLocaleTimeString();
+      $dbg.innerHTML += t + ' ' + msg + '<br>';
+      $dbg.scrollTop = $dbg.scrollHeight;
+    }
+    dbg('init');
+
     const TOAST_DURATION_MS = 2500;
-    const RECONNECT_DELAY_MS = 2000;
+    const RECONNECT_BASE_MS = 1000;
+    const RECONNECT_MAX_MS = 30000;
     const SEND_TIMEOUT_MS = 5000;
     const SWIPE_THRESHOLD_PX = 100;
+    const HEARTBEAT_INTERVAL_MS = 25000;
+    const HEARTBEAT_TIMEOUT_MS = 10000;
 
     let ws = null;
     let targetSession = null;
     let pendingSend = null;
     let sessionsData = [];
     let captureDebounceTimer = null;
+    let reconnectAttempt = 0;
+    let reconnectTimer = null;
+    let heartbeatTimer = null;
+    let heartbeatTimeoutTimer = null;
+    let isConnecting = false;
+    let lastConnectTime = 0;
 
     // Event delegation for card clicks (safer than inline onclick)
     $sessions.addEventListener('click', (e) => {
@@ -1363,6 +1388,10 @@
       return /^[a-zA-Z0-9_-]+$/.test(id);
     }
 
+    function getSessionKey(session) {
+      return session.tty ? session.session_id + ':' + session.tty : session.session_id;
+    }
+
     function renderMarkdown(markdownText) {
       if (!markdownText) return '<span class="modal-message-empty">No messages yet</span>';
       if (typeof marked !== 'undefined') {
@@ -1379,7 +1408,7 @@
     }
 
     function getSessionById(id) {
-      return sessionsData.find(s => s.session_id === id);
+      return sessionsData.find(s => getSessionKey(s) === id);
     }
 
     function openModal(id) {
@@ -1797,6 +1826,7 @@
         if (!isValidSessionId(session.session_id)) return '';
 
         // Escape all user-provided content to prevent XSS
+        const sessionKey = getSessionKey(session);
         const dirName = escapeHtml(getDirName(session.cwd));
         const shortPath = escapeHtml(formatPath(session.cwd));
         const statusLabel = escapeHtml(STATUS[session.status]);
@@ -1804,7 +1834,7 @@
         const safeStatus = escapeHtml(session.status);
 
         return `
-          <div class="card ${safeStatus}" data-session-id="${escapeHtml(session.session_id)}">
+          <div class="card ${safeStatus}" data-session-id="${escapeHtml(sessionKey)}">
             <div class="card-status">
               <span class="card-status-dot"></span>
               <span>${statusLabel}</span>
@@ -1824,7 +1854,76 @@
       }).join('');
     }
 
+    function getReconnectDelay() {
+      const delay = Math.min(RECONNECT_BASE_MS * Math.pow(2, reconnectAttempt), RECONNECT_MAX_MS);
+      const jitter = delay * 0.3 * Math.random();
+      reconnectAttempt++;
+      return delay + jitter;
+    }
+
+    function startHeartbeat() {
+      stopHeartbeat();
+      heartbeatTimer = setInterval(() => {
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'ping' }));
+          heartbeatTimeoutTimer = setTimeout(() => {
+            // No pong received — connection is dead
+            forceReconnect();
+          }, HEARTBEAT_TIMEOUT_MS);
+        }
+      }, HEARTBEAT_INTERVAL_MS);
+    }
+
+    function stopHeartbeat() {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+      clearTimeout(heartbeatTimeoutTimer);
+      heartbeatTimeoutTimer = null;
+    }
+
+    function resetHeartbeatTimeout() {
+      clearTimeout(heartbeatTimeoutTimer);
+      heartbeatTimeoutTimer = null;
+    }
+
+    function teardownSocket() {
+      stopHeartbeat();
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+      if (ws) {
+        // Remove handlers to prevent double-reconnect
+        ws.onclose = null;
+        ws.onerror = null;
+        ws.onmessage = null;
+        try { ws.close(); } catch {}
+        ws = null;
+      }
+      isConnecting = false;
+    }
+
+    function forceReconnect() {
+      const age = Date.now() - lastConnectTime;
+      if (age < 3000) {
+        return;
+      }
+      dbg('reconnect');
+      teardownSocket();
+      setConn(false);
+      connect();
+    }
+
+    function scheduleReconnect() {
+      if (reconnectTimer) return;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        connect();
+      }, getReconnectDelay());
+    }
+
     function connect() {
+      // Prevent double-connections
+      if (isConnecting) return;
+
       const params = new URLSearchParams(window.location.search);
       const token = params.get('token');
 
@@ -1839,25 +1938,49 @@
         return;
       }
 
+      isConnecting = true;
+      lastConnectTime = Date.now();
       const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-      ws = new WebSocket(`${proto}//${location.host}?token=${token}`);
+      const wsUrl = `${proto}//${location.host}?token=${token}`;
+
+      try {
+        ws = new WebSocket(wsUrl);
+      } catch (ex) {
+        dbg('ws constructor error: ' + ex.message);
+        isConnecting = false;
+        return;
+      }
+      dbg('ws connecting');
 
       ws.onopen = () => {
+        dbg('ws open');
+        isConnecting = false;
+        reconnectAttempt = 0;
         setConn(true);
-        pendingSend = null; // Reset pending state on reconnect
+        pendingSend = null;
+        startHeartbeat();
       };
-      ws.onclose = () => {
-        setConn(false);
-        pendingSend = null; // Reset pending state on disconnect
-        setTimeout(connect, RECONNECT_DELAY_MS);
-      };
-      ws.onerror = () => {
+      ws.onclose = (e) => {
+        dbg('ws close code=' + e.code);
+        isConnecting = false;
         setConn(false);
         pendingSend = null;
+        stopHeartbeat();
+        scheduleReconnect();
+      };
+      ws.onerror = (e) => {
+        dbg('ws error');
+        isConnecting = false;
+        setConn(false);
+        pendingSend = null;
+        stopHeartbeat();
       };
       ws.onmessage = (event) => {
+        // Any message from server proves the connection is alive
+        resetHeartbeatTimeout();
         try {
           const msg = JSON.parse(event.data);
+          if (msg.type === 'pong') return; // Heartbeat response, nothing to render
           if (msg.type === 'sessions') {
             render(msg.data);
           } else if (msg.type === 'focusResult') {
@@ -1875,7 +1998,6 @@
           } else if (msg.type === 'clearSessionsResult') {
             if (!msg.success) toast(msg.error || 'Failed', 'err');
           } else if (msg.type === 'sendKeystrokeResult') {
-            // Handle keystroke result (from dpad or text input in waiting_input state)
             if (pendingSend) {
               pendingSend = null;
               $sendBtn.disabled = !$msgInput.value.trim();
@@ -1898,7 +2020,46 @@
       };
     }
 
+    // Fetch sessions immediately over HTTP — renders the page without
+    // waiting for the WebSocket (iOS Safari delays WS connections ~10-15s).
+    const params = new URLSearchParams(window.location.search);
+    const initToken = params.get('token');
+    if (initToken) {
+      fetch('/api/sessions?token=' + encodeURIComponent(initToken))
+        .then(r => r.json())
+        .then(msg => {
+          if (msg.data) {
+            render(msg.data);
+            setConn(true);
+          }
+        })
+        .catch(() => {});
+    }
+
     connect();
+
+    // iOS Safari: force reconnect when page returns to foreground.
+    // readyState LIES after iOS suspension — it reports OPEN on dead connections.
+    // So we always tear down and reconnect, regardless of readyState.
+    document.addEventListener('visibilitychange', () => {
+      dbg('visibility: ' + document.visibilityState);
+      if (document.visibilityState === 'visible') {
+        forceReconnect();
+      }
+    });
+
+    // BFCache: reconnect when restored from back-forward cache
+    window.addEventListener('pageshow', (event) => {
+      dbg('pageshow persisted=' + event.persisted);
+      if (event.persisted) {
+        forceReconnect();
+      }
+    });
+
+    // Stop heartbeat when page goes to background (socket may survive or die on its own)
+    window.addEventListener('pagehide', () => {
+      stopHeartbeat();
+    });
 
     // Prevent zoom
     document.body.addEventListener('touchmove', (e) => {

--- a/src/bin/ccm.tsx
+++ b/src/bin/ccm.tsx
@@ -154,9 +154,10 @@ program
   .description('Start web server for mobile monitoring')
   .option('-p, --port <port>', 'Port number', '3456')
   .option('-t, --tailscale', 'Prefer Tailscale IP for mobile access')
-  .action(async (options: { port: string; tailscale?: boolean }) => {
+  .option('--debug', 'Enable debug panel in web UI')
+  .action(async (options: { port: string; tailscale?: boolean; debug?: boolean }) => {
     const port = parseInt(options.port, 10);
-    await startServer({ port, preferTailscale: options.tailscale });
+    await startServer({ port, preferTailscale: options.tailscale, debug: options.debug });
   });
 
 /**

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -60,7 +60,7 @@ export function Dashboard({ initialShowQr, preferTailscale }: DashboardProps): R
   const focusSessionByIndex = (index: number) => {
     const session = sessions[index];
     if (session?.tty) {
-      focusSession(session.tty);
+      focusSession(session.tty, session.wezterm_pane_id);
     }
   };
 

--- a/src/hook/handler.ts
+++ b/src/hook/handler.ts
@@ -66,6 +66,7 @@ export async function handleHookEvent(eventName: string, tty?: string): Promise<
     session_id: rawInput.session_id,
     cwd,
     tty,
+    wezterm_pane_id: process.env.WEZTERM_PANE || undefined,
     hook_event_name: eventName,
     notification_type: rawInput.notification_type as string | undefined,
     transcript_path: transcriptPath,

--- a/src/hook/handler.ts
+++ b/src/hook/handler.ts
@@ -66,7 +66,10 @@ export async function handleHookEvent(eventName: string, tty?: string): Promise<
     session_id: rawInput.session_id,
     cwd,
     tty,
-    wezterm_pane_id: process.env.WEZTERM_PANE || undefined,
+    wezterm_pane_id:
+      process.env.WEZTERM_PANE && /^\d+$/.test(process.env.WEZTERM_PANE)
+        ? process.env.WEZTERM_PANE
+        : undefined,
     hook_event_name: eventName,
     notification_type: rawInput.notification_type as string | undefined,
     transcript_path: transcriptPath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,8 @@ export type {
   StoreData,
 } from './types/index.js';
 export {
-  execWezTermCli,
   focusSession,
   getSupportedTerminals,
-  hasWezTermCli,
   isMacOS,
 } from './utils/focus.js';
 export { sendTextToTerminal } from './utils/send-text.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,7 @@ export type {
   SessionStatus,
   StoreData,
 } from './types/index.js';
-export {
-  focusSession,
-  getSupportedTerminals,
-  isMacOS,
-} from './utils/focus.js';
+export { focusSession, getSupportedTerminals, isMacOS } from './utils/focus.js';
 export { sendTextToTerminal } from './utils/send-text.js';
 // Utilities
 export { getStatusDisplay } from './utils/status.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,13 @@ export type {
   SessionStatus,
   StoreData,
 } from './types/index.js';
-export { focusSession, getSupportedTerminals, isMacOS } from './utils/focus.js';
+export {
+  execWezTermCli,
+  focusSession,
+  getSupportedTerminals,
+  hasWezTermCli,
+  isMacOS,
+} from './utils/focus.js';
 export { sendTextToTerminal } from './utils/send-text.js';
 // Utilities
 export { getStatusDisplay } from './utils/status.js';

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -61,7 +61,14 @@ function generateAuthToken(): string {
 }
 
 interface WebSocketMessage {
-  type: 'sessions' | 'focus' | 'sendText' | 'sendKeystroke' | 'clearSessions' | 'captureScreen';
+  type:
+    | 'sessions'
+    | 'focus'
+    | 'sendText'
+    | 'sendKeystroke'
+    | 'clearSessions'
+    | 'captureScreen'
+    | 'ping';
   sessionId?: string;
   text?: string;
   key?: string;
@@ -100,18 +107,24 @@ function isDangerousCommand(text: string): boolean {
 }
 
 /**
- * Find a session by session ID.
+ * Find a session by session key (session_id:tty) or plain session_id.
  */
-function findSessionById(sessionId: string): Session | undefined {
+function findSessionByKey(sessionKey: string): Session | undefined {
   const sessions = getSessions();
-  return sessions.find((s) => s.session_id === sessionId);
+  // Try composite key match first (session_id:/dev/ttysNNN)
+  const match = sessions.find(
+    (s) => (s.tty ? `${s.session_id}:${s.tty}` : s.session_id) === sessionKey
+  );
+  if (match) return match;
+  // Fall back to plain session_id for backward compatibility
+  return sessions.find((s) => s.session_id === sessionKey);
 }
 
 /**
  * Handle focus command from WebSocket client.
  */
 function handleFocusCommand(ws: WebSocket, sessionId: string): void {
-  const session = findSessionById(sessionId);
+  const session = findSessionByKey(sessionId);
   if (!session?.tty) {
     ws.send(
       JSON.stringify({
@@ -143,7 +156,7 @@ function handleSendTextCommand(ws: WebSocket, sessionId: string, text: string): 
     return;
   }
 
-  const session = findSessionById(sessionId);
+  const session = findSessionByKey(sessionId);
   if (!session?.tty) {
     ws.send(JSON.stringify({ type: 'sendTextResult', success: false, error: 'Session not found' }));
     return;
@@ -162,7 +175,7 @@ function handleSendKeystrokeCommand(
   key: string,
   useControl = false
 ): void {
-  const session = findSessionById(sessionId);
+  const session = findSessionByKey(sessionId);
   if (!session?.tty) {
     ws.send(
       JSON.stringify({ type: 'sendKeystrokeResult', success: false, error: 'Session not found' })
@@ -196,7 +209,7 @@ function handleClearSessionsCommand(ws: WebSocket): void {
  * Focuses the terminal window first, then captures it.
  */
 async function handleCaptureScreenCommand(ws: WebSocket, sessionId: string): Promise<void> {
-  const session = findSessionById(sessionId);
+  const session = findSessionByKey(sessionId);
   if (!session?.tty) {
     ws.send(
       JSON.stringify({
@@ -251,6 +264,11 @@ function handleWebSocketMessage(ws: WebSocket, data: Buffer): void {
     message = JSON.parse(data.toString()) as WebSocketMessage;
   } catch {
     return; // Ignore invalid messages
+  }
+
+  if (message.type === 'ping') {
+    ws.send(JSON.stringify({ type: 'pong' }));
+    return;
   }
 
   if (message.type === 'focus' && message.sessionId) {
@@ -326,6 +344,7 @@ function setupWebSocketHandlers(wss: WebSocketServer, validToken: string): void 
 export interface ServerOptions {
   port?: number;
   preferTailscale?: boolean;
+  debug?: boolean;
 }
 
 export interface ServerInfo {
@@ -378,6 +397,22 @@ function serveStatic(req: IncomingMessage, res: ServerResponse, validToken: stri
   const url = new URL(req.url || '/', `http://${req.headers.host}`);
   const requestToken = url.searchParams.get('token');
   const filePath = url.pathname === '/' ? '/index.html' : url.pathname;
+
+  // REST API: return sessions as JSON (used by client for instant load before WebSocket connects)
+  if (filePath === '/api/sessions') {
+    if (requestToken !== validToken) {
+      res.writeHead(401, { 'Content-Type': 'text/plain' });
+      res.end('Unauthorized');
+      return;
+    }
+    const sessions = getSessions();
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+    });
+    res.end(JSON.stringify({ type: 'sessions', data: sessions }));
+    return;
+  }
 
   // Allow static library files without token (they contain no sensitive data)
   const isPublicLibrary = filePath.startsWith('/lib/') && filePath.endsWith('.js');
@@ -467,12 +502,13 @@ function stopServerComponents({ watcher, wss, server }: ServerComponents): void 
 }
 
 export async function createMobileServer(options: ServerOptions = {}): Promise<ServerInfo> {
-  const { port = DEFAULT_SERVER_PORT, preferTailscale = false } = options;
+  const { port = DEFAULT_SERVER_PORT, preferTailscale = false, debug = false } = options;
   const { ip, localIP, tailscaleIP } = resolveServerIP(preferTailscale);
 
   const actualPort = await findAvailablePort(port, ip);
   const token = generateAuthToken();
-  const url = `http://${ip}:${actualPort}?token=${token}`;
+  const debugParam = debug ? '&debug=1' : '';
+  const url = `http://${ip}:${actualPort}?token=${token}${debugParam}`;
   const qrCode = await generateQRCode(url);
 
   const components = createServerComponents(token);
@@ -495,12 +531,13 @@ export async function createMobileServer(options: ServerOptions = {}): Promise<S
 
 // CLI standalone mode
 export async function startServer(options: ServerOptions = {}): Promise<void> {
-  const { port = DEFAULT_SERVER_PORT, preferTailscale = false } = options;
+  const { port = DEFAULT_SERVER_PORT, preferTailscale = false, debug = false } = options;
   const { ip, tailscaleIP } = resolveServerIP(preferTailscale);
 
   const actualPort = await findAvailablePort(port, ip);
   const token = generateAuthToken();
-  const url = `http://${ip}:${actualPort}?token=${token}`;
+  const debugParam = debug ? '&debug=1' : '';
+  const url = `http://${ip}:${actualPort}?token=${token}${debugParam}`;
 
   const components = createServerComponents(token);
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -122,7 +122,7 @@ function handleFocusCommand(ws: WebSocket, sessionId: string): void {
     );
     return;
   }
-  const success = focusSession(session.tty);
+  const success = focusSession(session.tty, session.wezterm_pane_id);
   ws.send(JSON.stringify({ type: 'focusResult', success }));
 }
 
@@ -148,7 +148,7 @@ function handleSendTextCommand(ws: WebSocket, sessionId: string, text: string): 
     ws.send(JSON.stringify({ type: 'sendTextResult', success: false, error: 'Session not found' }));
     return;
   }
-  const result = sendTextToTerminal(session.tty, text);
+  const result = sendTextToTerminal(session.tty, text, session.wezterm_pane_id);
   ws.send(JSON.stringify({ type: 'sendTextResult', ...result }));
 }
 
@@ -169,7 +169,7 @@ function handleSendKeystrokeCommand(
     );
     return;
   }
-  const result = sendKeystrokeToTerminal(session.tty, key, useControl);
+  const result = sendKeystrokeToTerminal(session.tty, key, useControl, session.wezterm_pane_id);
   ws.send(JSON.stringify({ type: 'sendKeystrokeResult', ...result }));
 }
 

--- a/src/store/file-store.ts
+++ b/src/store/file-store.ts
@@ -174,6 +174,7 @@ export function updateSession(event: HookEvent): Session {
     session_id: event.session_id,
     cwd: event.cwd,
     tty: event.tty ?? existing?.tty,
+    wezterm_pane_id: event.wezterm_pane_id ?? existing?.wezterm_pane_id,
     status: determineStatus(event, existing?.status),
     created_at: existing?.created_at ?? now,
     updated_at: now,

--- a/src/store/file-store.ts
+++ b/src/store/file-store.ts
@@ -125,19 +125,14 @@ export function determineStatus(event: HookEvent, currentStatus?: SessionStatus)
     return 'stopped';
   }
 
-  // UserPromptSubmit starts a new operation, so resume even if stopped
-  if (event.hook_event_name === 'UserPromptSubmit') {
+  // Active events resume even if stopped — if Claude Code is using tools, it's running
+  if (event.hook_event_name === 'UserPromptSubmit' || event.hook_event_name === 'PreToolUse') {
     return 'running';
   }
 
-  // Keep stopped state (don't resume except for UserPromptSubmit)
+  // Keep stopped state for non-active events (PostToolUse, Notification without permission)
   if (currentStatus === 'stopped') {
     return 'stopped';
-  }
-
-  // Active operation event
-  if (event.hook_event_name === 'PreToolUse') {
-    return 'running';
   }
 
   // Waiting for permission prompt

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export interface HookEvent {
   session_id: string;
   cwd: string;
   tty?: string;
+  wezterm_pane_id?: string;
   hook_event_name: HookEventName;
   notification_type?: string;
   transcript_path?: string;
@@ -24,6 +25,7 @@ export interface Session {
   session_id: string;
   cwd: string;
   tty?: string;
+  wezterm_pane_id?: string;
   status: SessionStatus;
   created_at: string;
   updated_at: string;

--- a/src/utils/focus.ts
+++ b/src/utils/focus.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { accessSync, constants, writeFileSync } from 'node:fs';
 import { executeAppleScript } from './applescript.js';
 import { executeWithTerminalFallback } from './terminal-strategy.js';
@@ -71,6 +72,46 @@ export function setTtyTitle(tty: string, title: string): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Cached result of WezTerm CLI availability check.
+ * @internal
+ */
+let wezTermCliAvailable: boolean | null = null;
+
+/**
+ * Check if the `wezterm` CLI binary is available on PATH.
+ * Result is cached after first invocation.
+ */
+export function hasWezTermCli(): boolean {
+  if (wezTermCliAvailable !== null) return wezTermCliAvailable;
+  try {
+    execFileSync('wezterm', ['--version'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+    wezTermCliAvailable = true;
+  } catch {
+    wezTermCliAvailable = false;
+  }
+  return wezTermCliAvailable;
+}
+
+/**
+ * Execute a WezTerm CLI command and return trimmed stdout, or null on failure.
+ */
+export function execWezTermCli(args: string[]): string | null {
+  try {
+    return execFileSync('wezterm', args, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    }).trim();
+  } catch {
+    return null;
   }
 }
 
@@ -193,11 +234,92 @@ function focusGhostty(tty: string): boolean {
   return executeAppleScript(buildGhosttyScript());
 }
 
+function buildWezTermActivateScript(): string {
+  return `
+tell application "WezTerm" to activate
+return true
+`;
+}
+
+function buildWezTermFocusByTitleScript(titleTag: string): string {
+  const safeTag = sanitizeForAppleScript(titleTag);
+  return `
+tell application "WezTerm" to activate
+delay 0.1
+
+tell application "System Events"
+  if not (exists process "wezterm-gui") then
+    return false
+  end if
+  tell process "wezterm-gui"
+    try
+      set windowMenu to menu "Window" of menu bar 1
+      set menuItems to every menu item of windowMenu whose name contains "${safeTag}"
+      if (count of menuItems) > 0 then
+        click item 1 of menuItems
+        delay 0.05
+        click item 1 of menuItems
+        delay 0.05
+        try
+          perform action "AXRaise" of window 1
+        end try
+        return true
+      end if
+    end try
+  end tell
+end tell
+return false
+`;
+}
+
+function focusWezTermViaCli(weztermPaneId: string): boolean {
+  const listOutput = execWezTermCli(['cli', 'list', '--format', 'json']);
+  if (!listOutput) return false;
+  try {
+    const panes = JSON.parse(listOutput) as Array<{ pane_id: number; tab_id: number }>;
+    const pane = panes.find((p) => p.pane_id === Number.parseInt(weztermPaneId, 10));
+    if (!pane) return false;
+    execWezTermCli(['cli', 'activate-tab', '--tab-id', String(pane.tab_id)]);
+    execWezTermCli(['cli', 'activate-pane', '--pane-id', weztermPaneId]);
+    executeAppleScript(buildWezTermActivateScript());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function focusWezTerm(tty: string, weztermPaneId?: string): boolean {
+  // CLI path: precise pane targeting when binary and pane ID are available
+  if (hasWezTermCli() && weztermPaneId && focusWezTermViaCli(weztermPaneId)) {
+    return true;
+  }
+
+  // AppleScript fallback: title-tag + Window menu (same pattern as Ghostty)
+  const titleTag = generateTitleTag(tty);
+  const titleSet = setTtyTitle(tty, titleTag);
+
+  if (titleSet) {
+    const waitScript = 'delay 0.2';
+    executeAppleScript(waitScript);
+  }
+
+  const success = executeAppleScript(buildWezTermFocusByTitleScript(titleTag));
+
+  if (titleSet) {
+    setTtyTitle(tty, '');
+  }
+
+  if (success) return true;
+
+  // Last resort: just activate WezTerm without specific pane focus
+  return executeAppleScript(buildWezTermActivateScript());
+}
+
 export function isMacOS(): boolean {
   return process.platform === 'darwin';
 }
 
-export function focusSession(tty: string): boolean {
+export function focusSession(tty: string, weztermPaneId?: string): boolean {
   if (!isMacOS()) return false;
   if (!isValidTtyPath(tty)) return false;
 
@@ -205,9 +327,10 @@ export function focusSession(tty: string): boolean {
     iTerm2: () => focusITerm2(tty),
     terminalApp: () => focusTerminalApp(tty),
     ghostty: () => focusGhostty(tty),
+    wezterm: () => focusWezTerm(tty, weztermPaneId),
   });
 }
 
 export function getSupportedTerminals(): string[] {
-  return ['iTerm2', 'Terminal.app', 'Ghostty'];
+  return ['iTerm2', 'Terminal.app', 'Ghostty', 'WezTerm'];
 }

--- a/src/utils/focus.ts
+++ b/src/utils/focus.ts
@@ -289,7 +289,7 @@ function focusWezTermViaCli(weztermPaneId: string): boolean {
     if (!Number.isSafeInteger(paneIdNum)) return false;
     const pane = panes.find(
       (p: Record<string, unknown>) => typeof p?.pane_id === 'number' && p.pane_id === paneIdNum
-    ) as { pane_id: number; tab_id: number; window_title?: string } | undefined;
+    ) as { pane_id: number; tab_id: number } | undefined;
     if (!pane) return false;
     // CLI activate-tab/pane switches focus within WezTerm
     execWezTermCli([

--- a/src/utils/focus.ts
+++ b/src/utils/focus.ts
@@ -276,9 +276,14 @@ function focusWezTermViaCli(weztermPaneId: string): boolean {
   const listOutput = execWezTermCli(['cli', 'list', '--format', 'json']);
   if (!listOutput) return false;
   try {
-    const panes = JSON.parse(listOutput) as Array<{ pane_id: number; tab_id: number }>;
-    const pane = panes.find((p) => p.pane_id === Number.parseInt(weztermPaneId, 10));
-    if (!pane) return false;
+    const panes = JSON.parse(listOutput) as unknown;
+    if (!Array.isArray(panes)) return false;
+    const paneIdNum = Number(weztermPaneId);
+    if (!Number.isSafeInteger(paneIdNum)) return false;
+    const pane = panes.find(
+      (p: Record<string, unknown>) => typeof p?.pane_id === 'number' && p.pane_id === paneIdNum
+    ) as { pane_id: number; tab_id: number } | undefined;
+    if (!pane || typeof pane.tab_id !== 'number') return false;
     execWezTermCli(['cli', 'activate-tab', '--tab-id', String(pane.tab_id)]);
     execWezTermCli(['cli', 'activate-pane', '--pane-id', weztermPaneId]);
     executeAppleScript(buildWezTermActivateScript());

--- a/src/utils/focus.ts
+++ b/src/utils/focus.ts
@@ -158,9 +158,10 @@ end tell
 
 function buildGhosttyScript(): string {
   return `
-tell application "Ghostty"
-  activate
+tell application "System Events"
+  if not (exists process "Ghostty") then return false
 end tell
+tell application "Ghostty" to activate
 return true
 `;
 }
@@ -168,14 +169,15 @@ return true
 function buildGhosttyFocusByTitleScript(titleTag: string): string {
   const safeTag = sanitizeForAppleScript(titleTag);
   return `
--- Activate Ghostty first (required when called from Web UI with Ghostty in background)
-tell application "Ghostty" to activate
-delay 0.1
-
 tell application "System Events"
   if not (exists process "Ghostty") then
     return false
   end if
+end tell
+tell application "Ghostty" to activate
+delay 0.1
+
+tell application "System Events"
   tell process "Ghostty"
     -- Search Window menu for the title tag (uses "name" attribute, not "title")
     try
@@ -236,6 +238,9 @@ function focusGhostty(tty: string): boolean {
 
 function buildWezTermActivateScript(): string {
   return `
+tell application "System Events"
+  if not (exists process "wezterm-gui") then return false
+end tell
 tell application "WezTerm" to activate
 return true
 `;
@@ -244,13 +249,15 @@ return true
 function buildWezTermFocusByTitleScript(titleTag: string): string {
   const safeTag = sanitizeForAppleScript(titleTag);
   return `
-tell application "WezTerm" to activate
-delay 0.1
-
 tell application "System Events"
   if not (exists process "wezterm-gui") then
     return false
   end if
+end tell
+tell application "WezTerm" to activate
+delay 0.1
+
+tell application "System Events"
   tell process "wezterm-gui"
     try
       set windowMenu to menu "Window" of menu bar 1
@@ -282,10 +289,55 @@ function focusWezTermViaCli(weztermPaneId: string): boolean {
     if (!Number.isSafeInteger(paneIdNum)) return false;
     const pane = panes.find(
       (p: Record<string, unknown>) => typeof p?.pane_id === 'number' && p.pane_id === paneIdNum
-    ) as { pane_id: number; tab_id: number } | undefined;
-    if (!pane || typeof pane.tab_id !== 'number') return false;
-    execWezTermCli(['cli', 'activate-tab', '--tab-id', String(pane.tab_id)]);
+    ) as { pane_id: number; tab_id: number; window_title?: string } | undefined;
+    if (!pane) return false;
+    // CLI activate-tab/pane switches focus within WezTerm
+    execWezTermCli([
+      'cli',
+      'activate-tab',
+      '--tab-id',
+      String(pane.tab_id),
+      '--pane-id',
+      weztermPaneId,
+    ]);
     execWezTermCli(['cli', 'activate-pane', '--pane-id', weztermPaneId]);
+    // After CLI activates the pane, we need to raise the correct WezTerm window.
+    // Find all panes in the same window to get the window_id, then match by
+    // checking each System Events window's title against any tab title in that window.
+    const targetWindowId = (pane as Record<string, unknown>).window_id;
+    const windowPanes =
+      typeof targetWindowId === 'number'
+        ? (panes as Array<Record<string, unknown>>).filter(
+            (p) => p.window_id === targetWindowId && typeof p.title === 'string'
+          )
+        : [];
+    // Build list of possible window title matches (any tab title in the target window)
+    const titleHints = windowPanes.map((p) => String(p.title)).filter((t) => t.length > 0);
+
+    // Try each hint to find and raise the right System Events window
+    for (const hint of titleHints) {
+      const safeHint = sanitizeForAppleScript(hint);
+      const raised = executeAppleScript(`
+tell application "System Events"
+  if not (exists process "wezterm-gui") then return false
+  tell process "wezterm-gui"
+    repeat with w in every window
+      if name of w contains "${safeHint}" then
+        perform action "AXRaise" of w
+        return true
+      end if
+    end repeat
+  end tell
+end tell
+return false
+`);
+      if (raised) {
+        executeAppleScript('tell application "WezTerm" to activate');
+        return true;
+      }
+    }
+
+    // Fallback: just activate WezTerm (CLI already switched the right tab/pane)
     executeAppleScript(buildWezTermActivateScript());
     return true;
   } catch {
@@ -328,12 +380,15 @@ export function focusSession(tty: string, weztermPaneId?: string): boolean {
   if (!isMacOS()) return false;
   if (!isValidTtyPath(tty)) return false;
 
-  return executeWithTerminalFallback({
-    iTerm2: () => focusITerm2(tty),
-    terminalApp: () => focusTerminalApp(tty),
-    ghostty: () => focusGhostty(tty),
-    wezterm: () => focusWezTerm(tty, weztermPaneId),
-  });
+  return executeWithTerminalFallback(
+    {
+      iTerm2: () => focusITerm2(tty),
+      terminalApp: () => focusTerminalApp(tty),
+      ghostty: () => focusGhostty(tty),
+      wezterm: () => focusWezTerm(tty, weztermPaneId),
+    },
+    { preferWezTerm: !!weztermPaneId }
+  );
 }
 
 export function getSupportedTerminals(): string[] {

--- a/src/utils/screen-capture.ts
+++ b/src/utils/screen-capture.ts
@@ -220,6 +220,39 @@ return ""
 }
 
 /**
+ * Build AppleScript to find WezTerm window bounds by TTY (using title tag).
+ * Returns "x, y, width, height" format.
+ * @internal
+ */
+function buildWezTermWindowBoundsScript(titleTag: string): string {
+  const safeTag = sanitizeForAppleScript(titleTag);
+  return `
+tell application "System Events"
+  if not (exists process "wezterm-gui") then return ""
+  tell process "wezterm-gui"
+    repeat with sysWindow in windows
+      try
+        set windowTitle to name of sysWindow
+        if windowTitle contains "${safeTag}" then
+          set pos to position of sysWindow
+          set sz to size of sysWindow
+          return (item 1 of pos as text) & ", " & (item 2 of pos as text) & ", " & (item 1 of sz as text) & ", " & (item 2 of sz as text)
+        end if
+      end try
+    end repeat
+    if (count of windows) > 0 then
+      set sysWindow to window 1
+      set pos to position of sysWindow
+      set sz to size of sysWindow
+      return (item 1 of pos as text) & ", " & (item 2 of pos as text) & ", " & (item 1 of sz as text) & ", " & (item 2 of sz as text)
+    end if
+  end tell
+end tell
+return ""
+`;
+}
+
+/**
  * Capture iTerm2 window by TTY using region capture.
  * @internal
  */
@@ -275,6 +308,35 @@ async function captureGhostty(tty: string): Promise<string | null> {
 }
 
 /**
+ * Capture WezTerm window by TTY using region capture.
+ * @internal
+ */
+async function captureWezTerm(tty: string): Promise<string | null> {
+  const titleTag = generateTitleTag(tty);
+
+  // Set title tag for window identification
+  const titleSet = setTtyTitle(tty, titleTag);
+
+  if (titleSet) {
+    // Wait for title to propagate
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+
+  const script = buildWezTermWindowBoundsScript(titleTag);
+  const result = executeAppleScriptWithResult(script);
+
+  // Clear title to let shell restore it
+  if (titleSet) {
+    setTtyTitle(tty, '');
+  }
+
+  if (!result) return null;
+  const bounds = parseWindowBounds(result);
+  if (!bounds) return null;
+  return await captureRegion(bounds);
+}
+
+/**
  * Capture the terminal window associated with a TTY.
  * Identifies the correct terminal by matching TTY, then captures that specific window.
  *
@@ -300,6 +362,9 @@ export async function captureTerminalScreen(tty: string): Promise<string | null>
 
   const result3 = await captureGhostty(tty);
   if (result3) return result3;
+
+  const result4 = await captureWezTerm(tty);
+  if (result4) return result4;
 
   return null;
 }

--- a/src/utils/send-text.ts
+++ b/src/utils/send-text.ts
@@ -507,21 +507,23 @@ function sendKeystrokeToWezTerm(
 
 /**
  * Send text to a terminal session and execute it (press Enter).
- * Tries iTerm2, Terminal.app, and Ghostty in order.
+ * Tries iTerm2, Terminal.app, Ghostty, and WezTerm in order.
  *
  * @param tty - The TTY path of the target terminal session
  * @param text - The text to send to the terminal
- * @returns true if text was sent successfully, false otherwise
+ * @param weztermPaneId - Optional WezTerm pane ID for precise CLI targeting
+ * @returns Result object with success status
  *
  * @remarks
  * - This is macOS only (uses AppleScript)
  * - For iTerm2 and Terminal.app, targets specific TTY
- * - For Ghostty, sends to the active window (TTY targeting not supported)
- * - System Events usage for Ghostty may require accessibility permissions
+ * - For Ghostty and WezTerm, uses title-tag Window menu targeting as fallback
+ * - WezTerm CLI path avoids clipboard pollution when pane ID is available
  */
 export function sendTextToTerminal(
   tty: string,
-  text: string
+  text: string,
+  weztermPaneId?: string
 ): { success: boolean; error?: string } {
   if (!isMacOS()) {
     return { success: false, error: 'This feature is only available on macOS' };
@@ -540,7 +542,7 @@ export function sendTextToTerminal(
     iTerm2: () => sendTextToITerm2(tty, text),
     terminalApp: () => sendTextToTerminalApp(tty, text),
     ghostty: () => sendTextToGhostty(tty, text),
-    wezterm: () => sendTextToWezTerm(tty, text),
+    wezterm: () => sendTextToWezTerm(tty, text, weztermPaneId),
   });
 
   return success
@@ -604,7 +606,8 @@ const ESCAPE_KEY_CODE = 53;
 export function sendKeystrokeToTerminal(
   tty: string,
   key: string,
-  useControl = false
+  useControl = false,
+  weztermPaneId?: string
 ): { success: boolean; error?: string } {
   if (!isMacOS()) {
     return { success: false, error: 'This feature is only available on macOS' };
@@ -649,7 +652,7 @@ export function sendKeystrokeToTerminal(
     iTerm2: () => sendKeystrokeToITerm2(tty, key, useControl, useKeyCode),
     terminalApp: () => sendKeystrokeToTerminalApp(tty, key, useControl, useKeyCode),
     ghostty: () => sendKeystrokeToGhostty(tty, key, useControl, useKeyCode),
-    wezterm: () => sendKeystrokeToWezTerm(tty, key, useControl, useKeyCode),
+    wezterm: () => sendKeystrokeToWezTerm(tty, key, useControl, useKeyCode, weztermPaneId),
   });
 
   return success

--- a/src/utils/send-text.ts
+++ b/src/utils/send-text.ts
@@ -114,14 +114,15 @@ end tell
 function buildGhosttyFocusScript(titleTag: string): string {
   const safeTag = sanitizeForAppleScript(titleTag);
   return `
--- Activate Ghostty first (required when called from Web UI with Ghostty in background)
-tell application "Ghostty" to activate
-delay 0.1
-
 tell application "System Events"
   if not (exists process "Ghostty") then
     return false
   end if
+end tell
+tell application "Ghostty" to activate
+delay 0.1
+
+tell application "System Events"
   tell process "Ghostty"
     try
       set windowMenu to menu "Window" of menu bar 1
@@ -356,13 +357,15 @@ function sendKeystrokeToGhostty(
 function buildWezTermFocusScript(titleTag: string): string {
   const safeTag = sanitizeForAppleScript(titleTag);
   return `
-tell application "WezTerm" to activate
-delay 0.1
-
 tell application "System Events"
   if not (exists process "wezterm-gui") then
     return false
   end if
+end tell
+tell application "WezTerm" to activate
+delay 0.1
+
+tell application "System Events"
   tell process "wezterm-gui"
     try
       set windowMenu to menu "Window" of menu bar 1
@@ -538,12 +541,15 @@ export function sendTextToTerminal(
     return { success: false, error: validation.error };
   }
 
-  const success = executeWithTerminalFallback({
-    iTerm2: () => sendTextToITerm2(tty, text),
-    terminalApp: () => sendTextToTerminalApp(tty, text),
-    ghostty: () => sendTextToGhostty(tty, text),
-    wezterm: () => sendTextToWezTerm(tty, text, weztermPaneId),
-  });
+  const success = executeWithTerminalFallback(
+    {
+      iTerm2: () => sendTextToITerm2(tty, text),
+      terminalApp: () => sendTextToTerminalApp(tty, text),
+      ghostty: () => sendTextToGhostty(tty, text),
+      wezterm: () => sendTextToWezTerm(tty, text, weztermPaneId),
+    },
+    { preferWezTerm: !!weztermPaneId }
+  );
 
   return success
     ? { success: true }
@@ -601,6 +607,7 @@ const ESCAPE_KEY_CODE = 53;
  * @param tty - The TTY path of the target terminal session
  * @param key - Single character key to send (y, n, a, 1-9, escape, etc.)
  * @param useControl - If true, send with Control modifier (for Ctrl+C)
+ * @param weztermPaneId - Optional WezTerm pane ID for direct pane targeting
  * @returns Result object with success status
  */
 export function sendKeystrokeToTerminal(
@@ -648,12 +655,15 @@ export function sendKeystrokeToTerminal(
     useKeyCode = ENTER_KEY_CODE;
   }
 
-  const success = executeWithTerminalFallback({
-    iTerm2: () => sendKeystrokeToITerm2(tty, key, useControl, useKeyCode),
-    terminalApp: () => sendKeystrokeToTerminalApp(tty, key, useControl, useKeyCode),
-    ghostty: () => sendKeystrokeToGhostty(tty, key, useControl, useKeyCode),
-    wezterm: () => sendKeystrokeToWezTerm(tty, key, useControl, useKeyCode, weztermPaneId),
-  });
+  const success = executeWithTerminalFallback(
+    {
+      iTerm2: () => sendKeystrokeToITerm2(tty, key, useControl, useKeyCode),
+      terminalApp: () => sendKeystrokeToTerminalApp(tty, key, useControl, useKeyCode),
+      ghostty: () => sendKeystrokeToGhostty(tty, key, useControl, useKeyCode),
+      wezterm: () => sendKeystrokeToWezTerm(tty, key, useControl, useKeyCode, weztermPaneId),
+    },
+    { preferWezTerm: !!weztermPaneId }
+  );
 
   return success
     ? { success: true }

--- a/src/utils/send-text.ts
+++ b/src/utils/send-text.ts
@@ -1,6 +1,8 @@
 import { executeAppleScript } from './applescript.js';
 import {
+  execWezTermCli,
   generateTitleTag,
+  hasWezTermCli,
   isMacOS,
   isValidTtyPath,
   sanitizeForAppleScript,
@@ -343,6 +345,166 @@ function sendKeystrokeToGhostty(
   return executeAppleScript(buildGhosttyKeystrokeScript(key, useControl, useKeyCode));
 }
 
+// ============================================
+// WezTerm Functions
+// ============================================
+
+/**
+ * Build AppleScript to focus WezTerm window by title tag in Window menu.
+ * Uses the same pattern as Ghostty: activate app, find menu item by title tag.
+ */
+function buildWezTermFocusScript(titleTag: string): string {
+  const safeTag = sanitizeForAppleScript(titleTag);
+  return `
+tell application "WezTerm" to activate
+delay 0.1
+
+tell application "System Events"
+  if not (exists process "wezterm-gui") then
+    return false
+  end if
+  tell process "wezterm-gui"
+    try
+      set windowMenu to menu "Window" of menu bar 1
+      set menuItems to every menu item of windowMenu whose name contains "${safeTag}"
+      if (count of menuItems) > 0 then
+        click item 1 of menuItems
+        delay 0.05
+        click item 1 of menuItems
+        delay 0.05
+        try
+          perform action "AXRaise" of window 1
+        end try
+        return true
+      end if
+    end try
+  end tell
+end tell
+return false
+`;
+}
+
+/**
+ * Build AppleScript to send text to WezTerm via clipboard paste.
+ * Uses clipboard and Cmd+V to paste text, then sends Enter key.
+ */
+function buildWezTermSendTextScript(text: string): string {
+  const safeText = sanitizeForAppleScript(text);
+  return `
+set the clipboard to "${safeText}"
+delay 0.1
+tell application "System Events"
+  tell process "wezterm-gui"
+    keystroke "v" using command down
+    delay 0.2
+    keystroke return
+  end tell
+end tell
+return true
+`;
+}
+
+/**
+ * Send text to WezTerm terminal.
+ * Prefers CLI send-text when available (no clipboard pollution),
+ * falls back to AppleScript clipboard paste.
+ */
+function sendTextToWezTerm(tty: string, text: string, weztermPaneId?: string): boolean {
+  // CLI path: direct send-text (no clipboard pollution!)
+  if (hasWezTermCli() && weztermPaneId) {
+    const result = execWezTermCli([
+      'cli',
+      'send-text',
+      '--pane-id',
+      weztermPaneId,
+      '--no-paste',
+      `${text}\n`,
+    ]);
+    if (result !== null) return true;
+  }
+
+  // AppleScript fallback: focus via title-tag, then clipboard paste
+  const titleTag = generateTitleTag(tty);
+  const titleSet = setTtyTitle(tty, titleTag);
+
+  if (titleSet) {
+    const waitScript = 'delay 0.2';
+    executeAppleScript(waitScript);
+  }
+
+  const focusScript = buildWezTermFocusScript(titleTag);
+  executeAppleScript(focusScript);
+
+  if (titleSet) {
+    setTtyTitle(tty, '');
+  }
+
+  return executeAppleScript(buildWezTermSendTextScript(text));
+}
+
+/**
+ * Build AppleScript to send a single keystroke to WezTerm.
+ */
+function buildWezTermKeystrokeScript(key: string, useControl = false, useKeyCode?: number): string {
+  const safeKey = sanitizeForAppleScript(key);
+  const modifiers = useControl ? ' using control down' : '';
+  const keystrokeCmd =
+    useKeyCode !== undefined ? `key code ${useKeyCode}` : `keystroke "${safeKey}"${modifiers}`;
+  return `
+delay 0.1
+tell application "System Events"
+  tell process "wezterm-gui"
+    ${keystrokeCmd}
+  end tell
+end tell
+return true
+`;
+}
+
+/**
+ * Send a single keystroke to WezTerm.
+ * Prefers CLI send-text for simple character keys,
+ * falls back to AppleScript for special keys and Ctrl+C.
+ */
+function sendKeystrokeToWezTerm(
+  tty: string,
+  key: string,
+  useControl = false,
+  useKeyCode?: number,
+  weztermPaneId?: string
+): boolean {
+  // CLI path: for simple character keys, use send-text
+  if (hasWezTermCli() && weztermPaneId && useKeyCode === undefined && !useControl) {
+    const result = execWezTermCli([
+      'cli',
+      'send-text',
+      '--pane-id',
+      weztermPaneId,
+      '--no-paste',
+      key,
+    ]);
+    if (result !== null) return true;
+  }
+
+  // AppleScript path: for special keys (arrows, escape, enter) and Ctrl+C
+  const titleTag = generateTitleTag(tty);
+  const titleSet = setTtyTitle(tty, titleTag);
+
+  if (titleSet) {
+    const waitScript = 'delay 0.2';
+    executeAppleScript(waitScript);
+  }
+
+  const focusScript = buildWezTermFocusScript(titleTag);
+  executeAppleScript(focusScript);
+
+  if (titleSet) {
+    setTtyTitle(tty, '');
+  }
+
+  return executeAppleScript(buildWezTermKeystrokeScript(key, useControl, useKeyCode));
+}
+
 /**
  * Send text to a terminal session and execute it (press Enter).
  * Tries iTerm2, Terminal.app, and Ghostty in order.
@@ -378,6 +540,7 @@ export function sendTextToTerminal(
     iTerm2: () => sendTextToITerm2(tty, text),
     terminalApp: () => sendTextToTerminalApp(tty, text),
     ghostty: () => sendTextToGhostty(tty, text),
+    wezterm: () => sendTextToWezTerm(tty, text),
   });
 
   return success
@@ -486,6 +649,7 @@ export function sendKeystrokeToTerminal(
     iTerm2: () => sendKeystrokeToITerm2(tty, key, useControl, useKeyCode),
     terminalApp: () => sendKeystrokeToTerminalApp(tty, key, useControl, useKeyCode),
     ghostty: () => sendKeystrokeToGhostty(tty, key, useControl, useKeyCode),
+    wezterm: () => sendKeystrokeToWezTerm(tty, key, useControl, useKeyCode),
   });
 
   return success

--- a/src/utils/terminal-strategy.ts
+++ b/src/utils/terminal-strategy.ts
@@ -7,16 +7,22 @@ export interface TerminalOperations {
   iTerm2: () => boolean;
   terminalApp: () => boolean;
   ghostty: () => boolean;
+  wezterm: () => boolean;
 }
 
 /**
  * Execute terminal operation with fallback strategy.
- * Tries iTerm2 → Terminal.app → Ghostty in order, returning on first success.
+ * Tries iTerm2 → Terminal.app → Ghostty → WezTerm in order, returning on first success.
  *
  * @param operations - Terminal-specific operation functions
  * @returns true if any terminal operation succeeded, false otherwise
  */
 export function executeWithTerminalFallback(operations: TerminalOperations): boolean {
-  const strategies = [operations.iTerm2, operations.terminalApp, operations.ghostty];
+  const strategies = [
+    operations.iTerm2,
+    operations.terminalApp,
+    operations.ghostty,
+    operations.wezterm,
+  ];
   return strategies.some((op) => op());
 }

--- a/src/utils/terminal-strategy.ts
+++ b/src/utils/terminal-strategy.ts
@@ -12,17 +12,19 @@ export interface TerminalOperations {
 
 /**
  * Execute terminal operation with fallback strategy.
- * Tries iTerm2 → Terminal.app → Ghostty → WezTerm in order, returning on first success.
+ * Default order: iTerm2 → Terminal.app → Ghostty → WezTerm.
+ * When preferWezTerm is true, WezTerm is tried first (useful when a pane ID signals the session is in WezTerm).
  *
  * @param operations - Terminal-specific operation functions
+ * @param options - Optional configuration
  * @returns true if any terminal operation succeeded, false otherwise
  */
-export function executeWithTerminalFallback(operations: TerminalOperations): boolean {
-  const strategies = [
-    operations.iTerm2,
-    operations.terminalApp,
-    operations.ghostty,
-    operations.wezterm,
-  ];
+export function executeWithTerminalFallback(
+  operations: TerminalOperations,
+  options?: { preferWezTerm?: boolean }
+): boolean {
+  const strategies = options?.preferWezTerm
+    ? [operations.wezterm, operations.iTerm2, operations.terminalApp, operations.ghostty]
+    : [operations.iTerm2, operations.terminalApp, operations.ghostty, operations.wezterm];
   return strategies.some((op) => op());
 }

--- a/tests/focus.test.ts
+++ b/tests/focus.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  execWezTermCli,
   focusSession,
   generateOscTitleSequence,
   generateTitleTag,
   getSupportedTerminals,
+  hasWezTermCli,
   isMacOS,
   isValidTtyPath,
   sanitizeForAppleScript,
@@ -149,11 +151,32 @@ describe('focus', () => {
       expect(terminals).toContain('iTerm2');
       expect(terminals).toContain('Terminal.app');
       expect(terminals).toContain('Ghostty');
+      expect(terminals).toContain('WezTerm');
     });
 
-    it('should return exactly 3 terminals', () => {
+    it('should return exactly 4 terminals', () => {
       const terminals = getSupportedTerminals();
-      expect(terminals).toHaveLength(3);
+      expect(terminals).toHaveLength(4);
+    });
+  });
+
+  describe('hasWezTermCli', () => {
+    it('should return a boolean', () => {
+      const result = hasWezTermCli();
+      expect(typeof result).toBe('boolean');
+    });
+
+    it('should return consistent results (cached)', () => {
+      const first = hasWezTermCli();
+      const second = hasWezTermCli();
+      expect(first).toBe(second);
+    });
+  });
+
+  describe('execWezTermCli', () => {
+    it('should return null for invalid command', () => {
+      const result = execWezTermCli(['--invalid-command-that-does-not-exist']);
+      expect(result).toBeNull();
     });
   });
 
@@ -179,6 +202,13 @@ describe('focus', () => {
         value: 'linux',
       });
       expect(focusSession('/dev/pts/0')).toBe(false);
+    });
+
+    it('should accept optional weztermPaneId parameter', () => {
+      if (process.platform === 'darwin') {
+        // Should not throw when weztermPaneId is provided
+        expect(focusSession('/invalid/path', '42')).toBe(false);
+      }
     });
   });
 });


### PR DESCRIPTION
## Add WezTerm terminal support and improve mobile web reliability

Hey, I spent some time getting this to work, I also had some trouble using my iPhone so it reworked some of the websocket interaction to get that going. If you'd like me to break these up I can do that, but it is working in WezTerm and Ghostty for me now.

### WezTerm Support

Adds WezTerm as the 4th supported terminal (alongside iTerm2, Terminal.app, and Ghostty) with full feature parity across all operations: focus, send-text, keystroke, and screen capture.

**Dual-path hybrid**: WezTerm CLI as primary for precise pane targeting, with AppleScript title-tag fallback when the CLI is unavailable.

- **CLI path (preferred)**: Uses `wezterm cli list --format json` to discover panes, `activate-tab`/`activate-pane` for focus, and `send-text --no-paste` for text input. The CLI is preferred because it targets panes by ID — meaning it works correctly even with multiple WezTerm windows, split panes, and tabs without any ambiguity. It also avoids clipboard pollution since `send-text --no-paste` writes directly to the pane's input, unlike the AppleScript path which has to hijack the system clipboard with Cmd+V. The other terminals (iTerm2, Terminal.app) expose TTY-level targeting through their AppleScript dictionaries, but WezTerm's AppleScript support is minimal — the CLI is where WezTerm's real automation surface lives.
- **AppleScript fallback**: Sets an OSC title tag on the TTY (e.g., `ccm:ttys001`), searches WezTerm's Window menu for the tag, then interacts via System Events — identical pattern to existing Ghostty support. This path exists for cases where the `wezterm` binary isn't on PATH or the pane ID wasn't captured (e.g., sessions started before the hook was installed).

The CLI path is preferred when the `wezterm` binary is on PATH and a pane ID is available. Otherwise, the AppleScript path activates automatically.

**Hook capture**: The `$WEZTERM_PANE` environment variable is captured during hook events (with numeric validation) and stored on the session object. This enables precise pane targeting through the CLI path. `WEZTERM_PANE` is set automatically by WezTerm in every shell it spawns — it contains the numeric pane ID. When someone isn't using WezTerm, the variable doesn't exist and `wezterm_pane_id` stays `undefined`, so everything falls back to AppleScript.

**Terminal strategy**: The fallback order is now iTerm2 → Terminal.app → Ghostty → WezTerm by default. When a `wezterm_pane_id` is present, WezTerm is tried first since we know the session is running in WezTerm.

### Mobile Web Reliability

The mobile web UI had several reliability issues, particularly on iOS Safari:

1. **Dead connections went undetected.** iOS Safari suspends background tabs and kills WebSocket connections silently — `readyState` continues to report `OPEN` on a dead socket. Added a ping/pong heartbeat (25s interval, 10s timeout) that detects dead connections and forces a reconnect.

2. **Reconnects were aggressive at first.** A fixed 2s retry caused rapid reconnect storms when the server was down. Replaced with exponential backoff (1s base, 30s max) with 30% jitter.

3. **iOS visibility/BFCache transitions broke the connection.** Added `visibilitychange` and `pageshow` event listeners that tear down and reconnect the socket when the page returns to the foreground or is restored from back-forward cache.

4. **Initial page load was blank until WebSocket connected.** On iOS Safari, WebSocket connections can take 10-15s to establish. Added a REST `/api/sessions` endpoint that the client fetches immediately on load, so sessions render instantly while the WebSocket connects in the background.

5. **Session lookup was ambiguous.** When multiple sessions shared the same `session_id` (different TTYs), the web UI couldn't target the correct one. Session cards now use composite keys (`session_id:tty`) with backward-compatible fallback to plain `session_id`.

6. **Stopped sessions didn't resume on `PreToolUse`.** If Claude Code resumed tool use after a `Stop` event, the session stayed in `stopped` state. `PreToolUse` now resumes stopped sessions the same way `UserPromptSubmit` does.

7. **WebSocket connections hung indefinitely after extended background.** iOS Safari's networking stack can fail to complete new WebSocket handshakes after returning from minutes-long suspension — `onopen`/`onclose`/`onerror` never fire. Added a 5s connect timeout that detects the hung state and retries. After 2 consecutive connection failures (including fast `close code=1006` errors, not just timeouts), the client falls back to HTTP polling `/api/sessions` every 3s so the UI stays live even when WebSocket never recovers. Polling stops automatically once WebSocket reconnects.

8. **Keyboard auto-opened on iOS resume.** When returning to Safari from another app, iOS re-focused the message textarea and opened the keyboard, obscuring the UI. The textarea is now blurred on `visibilitychange` before reconnecting.

9. **Debug panel.** Added an opt-in debug panel (`?debug=1` or `ccm serve --debug`) that logs WebSocket lifecycle events — useful for diagnosing mobile connectivity issues without devtools.

### Security

- `execFileSync` (not `execSync`) for all CLI calls — prevents shell injection
- `$WEZTERM_PANE` validated with `/^\d+$/` regex at the trust boundary
- Runtime validation of `wezterm cli list` JSON output (`Array.isArray`, `Number.isSafeInteger`, `typeof` checks)
- All AppleScript strings sanitized via `sanitizeForAppleScript`
- TTY paths validated with strict regex before use
- REST `/api/sessions` endpoint validates auth token

### Files Changed (13)

| File                             | Change                                                       |
|----------------------------------|--------------------------------------------------------------|
| `src/types/index.ts`             | `wezterm_pane_id` on HookEvent and Session                   |
| `src/utils/terminal-strategy.ts` | `wezterm` in interface, `preferWezTerm` option               |
| `src/hook/handler.ts`            | Capture `$WEZTERM_PANE` with validation                      |
| `src/store/file-store.ts`        | Propagate `wezterm_pane_id`, `PreToolUse` resumes stopped    |
| `src/utils/focus.ts`             | Full WezTerm focus (CLI + AppleScript)                       |
| `src/utils/send-text.ts`         | Full WezTerm send-text and keystroke                         |
| `src/utils/screen-capture.ts`    | WezTerm screen capture                                       |
| `src/index.ts`                   | Clean public API exports                                     |
| `src/server/index.ts`            | Composite session keys, ping/pong, REST endpoint, debug flag |
| `src/bin/ccm.tsx`                | `--debug` flag for `ccm serve`                               |
| `src/components/Dashboard.tsx`   | Thread `wezterm_pane_id` to focus                            |
| `public/index.html`              | Heartbeat, reconnect backoff, iOS workarounds, debug panel   |
| `tests/focus.test.ts`            | WezTerm-specific tests                                       |

### Known Limitations

- `hasWezTermCli()` cache doesn't expire — restart monitor after installing WezTerm
- Stale pane IDs after WezTerm restart (inherent to env var capture at hook time)
- Screen capture uses its own async fallback chain rather than `executeWithTerminalFallback` (sync) — matches pre-existing Ghostty pattern

Debug Pane Screenshots (opt-in with --debug)

That is max height of the open debug pane on the right.

<img width="256" height="485" alt="image" src="https://github.com/user-attachments/assets/1e686778-3f42-44bb-8621-d3f701ae9fa9" />  <img width="217" height="468" alt="image" src="https://github.com/user-attachments/assets/378dc204-6416-46c6-8651-f34dcd8285a9" />

