### PR TITLE
feat: support CLAUDE_CONFIG_DIR environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,20 @@ With `-t` option, the QR code URL uses your Tailscale IP (100.x.x.x), allowing a
 | `-t, --tailscale` | Prefer Tailscale IP for mobile access |
 | `-p, --port <port>` | Specify port (serve command only) |
 
+### Custom Config Directory
+
+If you use `CLAUDE_CONFIG_DIR` to run Claude Code with a custom config directory, `ccm` respects it automatically:
+
+```bash
+# Setup hooks in custom config directory
+CLAUDE_CONFIG_DIR=~/.claude-work ccm setup
+
+# Monitor with custom config
+CLAUDE_CONFIG_DIR=~/.claude-work ccm
+```
+
+> By default, `ccm` uses `~/.claude/`. Set `CLAUDE_CONFIG_DIR` to match the value you pass to Claude Code.
+
 ### Keybindings
 
 | Key | Action |
@@ -186,7 +200,7 @@ Monitor and control Claude Code sessions from your smartphone.
 For reliable focus functionality with multiple tabs, `ccm` or `ccm setup` will prompt you to add the following setting:
 
 ```json
-// ~/.claude/settings.json
+// ~/.claude/settings.json (or $CLAUDE_CONFIG_DIR/settings.json)
 {
   "env": {
     "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1"
@@ -205,7 +219,7 @@ If you skipped this during setup and want to enable it later, add the setting ma
 ### Sessions not showing
 
 1. Run `ccm setup` to verify hook configuration
-2. Check `~/.claude/settings.json` for hook settings
+2. Check `~/.claude/settings.json` (or `$CLAUDE_CONFIG_DIR/settings.json`) for hook settings
 3. Restart Claude Code
 
 ### Focus not working
@@ -231,7 +245,7 @@ ccm clear
 > and gain control of your terminal sessions, including the ability to execute arbitrary commands.
 
 - **No data sent to external servers** - All data stays on your machine
-- Hook registration modifies `~/.claude/settings.json`
+- Hook registration modifies `~/.claude/settings.json` (or `$CLAUDE_CONFIG_DIR/settings.json`)
 - Focus feature uses AppleScript for terminal control
 - Mobile Web uses token authentication on local network only
 - Server-side validation blocks dangerous shell commands

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -1,12 +1,9 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { HOOK_EVENTS, PACKAGE_NAME } from '../constants.js';
+import { getClaudeConfigDir } from '../utils/claude-config.js';
 import { askConfirmation } from '../utils/prompt.js';
-
-const CLAUDE_DIR = join(homedir(), '.claude');
-const SETTINGS_FILE = join(CLAUDE_DIR, 'settings.json');
 
 /** Environment variable key to disable Claude Code terminal title override */
 const DISABLE_TITLE_ENV_KEY = 'CLAUDE_CODE_DISABLE_TERMINAL_TITLE';
@@ -127,11 +124,12 @@ function createHookEntry(eventName: string, baseCommand: string): HookEntry {
  * Load existing settings.json or return empty settings
  */
 function loadSettings(): Settings {
-  if (!existsSync(SETTINGS_FILE)) {
+  const settingsFile = join(getClaudeConfigDir(), 'settings.json');
+  if (!existsSync(settingsFile)) {
     return {};
   }
   try {
-    const content = readFileSync(SETTINGS_FILE, 'utf-8');
+    const content = readFileSync(settingsFile, 'utf-8');
     return JSON.parse(content) as Settings;
   } catch {
     console.error('Warning: Failed to parse existing settings.json, creating new one');
@@ -166,7 +164,8 @@ function showSetupPreview(
   hooksToSkip: string[],
   settingsExist: boolean
 ): void {
-  console.log(`Target file: ${SETTINGS_FILE}`);
+  const settingsFile = join(getClaudeConfigDir(), 'settings.json');
+  console.log(`Target file: ${settingsFile}`);
   console.log(settingsExist ? '(file exists, will be modified)' : '(file will be created)');
   console.log('');
   console.log('The following hooks will be added:');
@@ -187,6 +186,7 @@ function showSetupPreview(
  * Apply hooks to settings and save to file
  */
 function applyHooks(settings: Settings, hooksToAdd: string[], baseCommand: string): void {
+  const settingsFile = join(getClaudeConfigDir(), 'settings.json');
   if (!settings.hooks) {
     settings.hooks = {};
   }
@@ -200,7 +200,7 @@ function applyHooks(settings: Settings, hooksToAdd: string[], baseCommand: strin
     }
   }
 
-  writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2), {
+  writeFileSync(settingsFile, JSON.stringify(settings, null, 2), {
     encoding: 'utf-8',
     mode: 0o600,
   });
@@ -210,12 +210,13 @@ function applyHooks(settings: Settings, hooksToAdd: string[], baseCommand: strin
  * Check if hooks are already configured
  */
 export function isHooksConfigured(): boolean {
-  if (!existsSync(SETTINGS_FILE)) {
+  const settingsFile = join(getClaudeConfigDir(), 'settings.json');
+  if (!existsSync(settingsFile)) {
     return false;
   }
 
   try {
-    const content = readFileSync(SETTINGS_FILE, 'utf-8');
+    const content = readFileSync(settingsFile, 'utf-8');
     const settings = JSON.parse(content) as Settings;
 
     if (!settings.hooks) {
@@ -244,12 +245,15 @@ export async function setupHooks(): Promise<void> {
   console.log(`Using command: ${baseCommand}`);
   console.log('');
 
-  // Ensure .claude directory exists
-  if (!existsSync(CLAUDE_DIR)) {
-    mkdirSync(CLAUDE_DIR, { recursive: true });
+  const claudeDir = getClaudeConfigDir();
+  const settingsFile = join(claudeDir, 'settings.json');
+
+  // Ensure claude config directory exists
+  if (!existsSync(claudeDir)) {
+    mkdirSync(claudeDir, { recursive: true });
   }
 
-  const settingsExist = existsSync(SETTINGS_FILE);
+  const settingsExist = existsSync(settingsFile);
   const settings = loadSettings();
   const { toAdd: hooksToAdd, toSkip: hooksToSkip } = categorizeHooks(settings);
 
@@ -277,7 +281,7 @@ export async function setupHooks(): Promise<void> {
       applyHooks(settings, hooksToAdd, baseCommand);
       hooksApplied = true;
       console.log('');
-      console.log(`Added ${hooksToAdd.length} hook(s) to ${SETTINGS_FILE}`);
+      console.log(`Added ${hooksToAdd.length} hook(s) to ${settingsFile}`);
     } else {
       console.log('');
       console.log('Hook setup skipped.');
@@ -293,7 +297,7 @@ export async function setupHooks(): Promise<void> {
     const envConfirmed = await askConfirmation('Add CLAUDE_CODE_DISABLE_TERMINAL_TITLE setting?');
     // Save decision so we don't ask again
     applyGhosttyTitleSetting(settings, envConfirmed);
-    writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2), {
+    writeFileSync(settingsFile, JSON.stringify(settings, null, 2), {
       encoding: 'utf-8',
       mode: 0o600,
     });
@@ -335,7 +339,8 @@ export async function promptGhosttySettingIfNeeded(): Promise<void> {
   const envConfirmed = await askConfirmation('Add CLAUDE_CODE_DISABLE_TERMINAL_TITLE setting?');
 
   applyGhosttyTitleSetting(settings, envConfirmed);
-  writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2), {
+  const settingsFile = join(getClaudeConfigDir(), 'settings.json');
+  writeFileSync(settingsFile, JSON.stringify(settings, null, 2), {
     encoding: 'utf-8',
     mode: 0o600,
   });

--- a/src/utils/claude-config.ts
+++ b/src/utils/claude-config.ts
@@ -1,0 +1,12 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const DEFAULT_CLAUDE_DIR = '.claude';
+
+/**
+ * Get the Claude config directory path.
+ * Respects CLAUDE_CONFIG_DIR env variable, falls back to ~/.claude/
+ */
+export function getClaudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), DEFAULT_CLAUDE_DIR);
+}

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -1,15 +1,15 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { getClaudeConfigDir } from './claude-config.js';
 
 /**
  * Build transcript file path from cwd and session_id.
- * Claude Code stores transcripts at ~/.claude/projects/{encoded-cwd}/{session_id}.jsonl
+ * Claude Code stores transcripts at {claude-config-dir}/projects/{encoded-cwd}/{session_id}.jsonl
  */
 export function buildTranscriptPath(cwd: string, sessionId: string): string {
   // Encode cwd: replace / and . with - (including leading /)
   const encodedCwd = cwd.replace(/[/.]/g, '-');
-  return join(homedir(), '.claude', 'projects', encodedCwd, `${sessionId}.jsonl`);
+  return join(getClaudeConfigDir(), 'projects', encodedCwd, `${sessionId}.jsonl`);
 }
 
 interface ContentBlock {


### PR DESCRIPTION
## Summary

- Add support for the `CLAUDE_CONFIG_DIR` environment variable that Claude Code uses to customize its config directory
- Create a `getClaudeConfigDir()` utility that resolves the config path (respects `CLAUDE_CONFIG_DIR`, falls back to `~/.claude/`)
- Replace all hardcoded `~/.claude/` references in setup and transcript logic

## Motivation

When users run Claude Code with `CLAUDE_CONFIG_DIR=~/.claude-work claude`, the hooks and transcripts live under that custom directory. Previously, `ccm setup` always wrote to `~/.claude/settings.json`, which meant hooks were configured in the wrong location.

## Changes

- **New**: `src/utils/claude-config.ts` — `getClaudeConfigDir()` utility function
- **Edit**: `src/setup/index.ts` — replaced hardcoded `CLAUDE_DIR`/`SETTINGS_FILE` constants with runtime calls
- **Edit**: `src/utils/transcript.ts` — replaced hardcoded `~/.claude` path
- **Edit**: `README.md` — documented the feature with usage examples

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (2 pre-existing AppleScript timeout failures unrelated)
- [x] Manual: `CLAUDE_CONFIG_DIR=/tmp/claude-config-test ccm setup` targets `/tmp/claude-config-test/settings.json`
- [x] Manual: without env var, falls back to default `~/.claude/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)